### PR TITLE
revamp of c.in input file and minor fix for CONF.INP

### DIFF
--- a/src/conf.f90
+++ b/src/conf.f90
@@ -2982,7 +2982,7 @@ Contains
             If (len_trim(strcsave(1,i)) > maxlenconfig) maxlenconfig = len_trim(strcsave(1,i))
         End Do
 
-        ! Write table of configurations, L, S, J, energies, and weights of top 2 configurations to CONFFINAL.RES
+        ! Write table of configurations, L, S, J, energies, and weights of top 2 configurations to FINAL.RES
         Do j=1,Nlv
             ! Calculate g-factors if including L, S, J
             If (KLSJ == 1) Then

--- a/src/conf.f90
+++ b/src/conf.f90
@@ -2884,8 +2884,8 @@ Contains
             strfmt = '(I8,I6,F11.7)'
         End If
 
-        Open(99,file='CONFFINAL.RES',status='UNKNOWN')
-        Open(98,file='CONFLEVELS.RES',status='UNKNOWN')
+        Open(99,file='FINAL.RES',status='UNKNOWN')
+        Open(98,file='LEVELS.RES',status='UNKNOWN')
         Open(97,file='CONFSTR.RES',status='UNKNOWN')
 
         ! Form array of booleans of converged levels

--- a/src/conf_init.f90
+++ b/src/conf_init.f90
@@ -179,7 +179,7 @@ Module conf_init
         Do While (equals_in_str)
             Read(10, '(A)') line
             If (index(string=line, substring="=") == 0) Then
-                Backspace(10)
+                If (line /= "") Backspace(10) ! handle blank line before list of core orbitals
                 equals_in_str = .false.
             End If
         End Do
@@ -237,7 +237,7 @@ Module conf_init
         ! This subroutine calculates the total number of orbitals in conf-s
         Implicit None
 
-        Integer :: i, ic, ne0, nx, ny, nz, num_orbitals_per_line, counter
+        Integer :: i, j, ic, ne0, nx, ny, nz, num_orbitals_per_line, counter, num_lines
         Real(dp) :: x
         Real(dp), Dimension(:), Allocatable :: line
 
@@ -245,6 +245,18 @@ Module conf_init
         Allocate(line(num_orbitals_per_line))
 
         counter = 0
+
+        ! Read core orbitals
+        If (Nso /= 0) Then 
+            x = Nso/6
+            num_lines = Ceiling(x)
+            Do j=1,num_lines
+                Read (10,'(6(4X,F7.4))') (line(i), i=1,num_orbitals_per_line) 
+            End Do
+            counter = counter + Nso
+        End If
+
+        ! Read configuration list
         Do ic=1,Nc
             ne0=0
             Do While (ne0 < Ne)

--- a/src/formj2.f90
+++ b/src/formj2.f90
@@ -332,7 +332,7 @@ Module formj2
         Call MPI_AllReduce(ij8, NumJ, 1, MPI_INTEGER8, MPI_SUM, MPI_COMM_WORLD, mpierr)
 
         ! Write J^2 matrix to file CONFp.JJJ
-        If (Kl /= 1) Call WriteMatrix(Jsq,ij4,NumJ,'CONFp.JJJ',mype,npes,mpierr)
+        If (Kl /= 1 .and. Kw == 1) Call WriteMatrix(Jsq,ij4,NumJ,'CONFp.JJJ',mype,npes,mpierr)
 
         If (mype == 0) Then
             Write(counterStr,fmt='(I16)') NumJ


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Motivation/Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this fixes an open issue, include a link to the issue here. -->
Improve readability and usability of the c.in input file

## Description:
<!--- Describe your changes in detail here -->
- revamped c.in to use assignments instead of a list of numbers
- renamed CONFLEVELS.RES and CONFFINAL.RES files
- handle blank line before list of core orbitals and configurations
- remove default writing of CONFp.JJJ file