### PR TITLE
v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7] - 2024-11-17
+- refactored IP1 parameter out of pdtm.f90 and removed IP1 array size warnings
+- fixed formatting of Operator.RES files produced by pdtm
+- pdtm now skips transitions that have already been accounted for, e.g. b -> a is skipped if a -> b was done
+- introduced AllReduceD subroutine in mpi_utils.f90 to handle MPI_AllReduce for double precision
+- updated theory_lifetimes.py script to handle multiple input files
+- updated gen_job_script.py script to use scontrol show config to determine cluster information if using SLURM
+- fixed bug in reading K_sms
+- optimized gQED calculation
+
 ## [1.0.6] - 2024-10-30
 - refactored IPbr parameter out of params.f90
 - removed IPx dependency from pconf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(pci 
-        VERSION 1.0.5
+        VERSION 1.0.7
         DESCRIPTION "pCI software package"
         LANGUAGES Fortran)
 include(GNUInstallDirs)

--- a/py-lib/gen_job_script.py
+++ b/py-lib/gen_job_script.py
@@ -7,9 +7,14 @@ def write_job_script(path, code, num_nodes, num_procs_per_node, exclusive, mem, 
     This function writes a SLURM job script and returns the name of the job script.
     """
     
-    # Determine cluster information from SLURM_CLUSTER_NAME
-    cluster = os.getenv('SLURM_CLUSTER_NAME')
-    if not cluster:
+    # Determine cluster information from 'scontrol show config'
+    try:
+        scontrol_output = run(['scontrol','show','config'], capture_output=True, text=True, check=True)
+        for line in scontrol_output.stdout.splitlines():
+            if line.startswith('ClusterName'):
+                cluster = line.split('=')[1].strip()
+                print("Cluster found: " +  cluster)
+    except (CalledProcessError, FileNotFoundError):
         print("SLURM_CLUSTER_NAME environment variable not found. Job script will not be written.")
         return None
     

--- a/py-lib/theory_lifetimes.py
+++ b/py-lib/theory_lifetimes.py
@@ -32,7 +32,7 @@ def format_time_in_seconds(time):
         time_cut = time
         unit = 's'
     
-    str_time = f'{time_cut:.0f}' + ' ' + unit
+    str_time = f'{time_cut:.2f}' + ' ' + unit
         
     return str_time
         
@@ -52,6 +52,7 @@ def parse_dtm_res():
                                          'branching_ratio', 'transition_rate', 'state_one_energy', 'state_two_energy'])
     # Parse the RES files
     e1_res = parse_matrix_res('E1.RES')
+    e11_res = parse_matrix_res('E11.RES')
     e2_res = parse_matrix_res('E2.RES')
     e3_res = parse_matrix_res('E3.RES')
     
@@ -62,6 +63,7 @@ def parse_dtm_res():
     # Generate dictionary of matrix elements
     matrix_elements = {}
     if e1_res: add_res_to_dict('E1', e1_res, matrix_elements)
+    if e11_res: add_res_to_dict('E1', e11_res, matrix_elements)
     if e2_res: add_res_to_dict('E2', e2_res, matrix_elements)
     if e3_res: add_res_to_dict('E3', e3_res, matrix_elements)
     
@@ -89,7 +91,7 @@ def parse_dtm_res():
         for rate in rates:
             total_rates += rate[2]
         
-        lifetime = 1/total_rates*1e9
+        lifetime = 1/total_rates
         lifetimes.append([configuration, term, J, round(lifetime,3)])
         
         # skip to next configuration if conditions are met
@@ -159,7 +161,26 @@ def add_res_to_dict(matrix_element_type, res, lifetime_dict):
         termJ2 = term2 + J2
         energy2 = float(line[8])
         config2 = conf2 + ' ' + termJ2
-        
+
+        # skip line if matrix element already in lifetime_dict
+        match = False
+        try:
+            if len(lifetime_dict[config1]) > 0:
+                for item in lifetime_dict[config1]:
+                    if item[1] == config2:
+                        match = True
+                        break
+            if len(lifetime_dict[config2]) > 0:
+                for item in lifetime_dict[config2]:
+                    if item[1] == config1:
+                        match = True
+                        break
+        except:
+            pass
+
+        if match:
+            continue
+
         # matrix elementa
         matrix_element_val = float(line[6])
         

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -1161,7 +1161,7 @@ Contains
         Implicit None
         Integer :: ntr, lf, n, k, i, iq, j, ju, iu, nf, is, k1, icomp, err_stat, &
                    ic2, kx, n1, ic1, imin, n2, Ndpt, j1, j2, i1, iab2, l, &
-                   imax, nn, ntrm, ntrm1, start, End, mpierr, pgs0, pgs, pct, sizebin
+                   imax, nn, ntrm, ntrm1, start, end, mpierr, sizebin
         Integer :: npes,mype
         Integer*8 :: mem, memsum, count
         Real(dp) :: s, bn, bk, Tj, Etrm
@@ -1271,9 +1271,6 @@ Contains
             Else
                 n=sum(Ndc(1:start-1))
             End If
-            pgs0=sizebin/10
-            pgs=start+pgs0
-            pct=0
             Do ic1=start,end
                 n2 = Ndc(ic1)
                 Do n1=1,n2
@@ -1343,7 +1340,7 @@ Contains
     
         Deallocate(idet1,idet2)
         Return
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
 700     Write (*,*) 'FormDM: norma for vector ',ntr,' is ',s
         Return
         Return
@@ -1427,7 +1424,7 @@ Contains
         Implicit None
         Integer :: lf, imax, k, i, l1, l2, i1, n2, n21, n22, k1, icomp, ic, &
                   iq, j, ju, iu, nf, is, kx, ks, kxx, ixx, j1, j2, &
-                  imin, n, n1, ndpt, n20, jt, iab2, start, end, pgs, pgs0, pct
+                  imin, n, n1, ndpt, n20, jt, iab2, start, end
         Integer :: mype, npes, mpierr, sizebin, err_stat, err_stat2
         Integer*8 :: mem, memsum, count
         Real(dp) :: tj2, bn, bk, rc, rxx, s, ms, e1, e2
@@ -1572,9 +1569,6 @@ Contains
                     Ro=0.d0
                     imax=0
                     imin=1000
-                    pgs0=sizebin/10
-                    pgs=start+pgs0
-                    pct=0
                     Do n=start,end   !### - final state
                         Ndr=n
                         bn=B2(n)

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -1233,6 +1233,8 @@ Contains
                 i=1
                 existStr = .true.
             End If 
+
+            Call WriteHeaders
         End If
     
         ! Divide workload into npes
@@ -1511,6 +1513,8 @@ Contains
                 End Do
                 existStr = .true.
             End If 
+
+            Call WriteHeaders
         End If
 
         mem = sizeof(Iarr)+sizeof(Iarr2)+sizeof(B1)+sizeof(B2)+sizeof(ArrB2)
@@ -1922,7 +1926,7 @@ Contains
         strsp = ''
         nspaces1 = 0
         nspaces2 = 0
-        If (existStr == .false.) Then
+        If (.not. existStr) Then
             Write(strc1(k1),'(F3.1)') tj1
             Write(strt1(k1),'(F3.1)') tm1
             Write(strc2(k2),'(F3.1)') tj2
@@ -1945,13 +1949,6 @@ Contains
         wl = abs(1e7/delEcm)
         ! Print table for E1_L and E1_V
         If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_L||J2>  <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                Else
-                    Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>  <J1||E1_L||J2>  <J1||E1_V||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE1 /= 0.d0 .and. AE1V /= 0.d0) Then
@@ -1964,13 +1961,6 @@ Contains
             End If
         ! Print table for E1_L
         Else If (Keys%E1_L == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                Else
-                    Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE1 /= 0.d0) Then
@@ -1983,13 +1973,6 @@ Contains
             End If
         ! Print table for E1_V
         Else If (Keys%E1_V == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                Else
-                    Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE1V /= 0.d0) Then
@@ -2003,13 +1986,6 @@ Contains
         End If
         ! Print table for E2
         If (Keys%E2 == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(101,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E2 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||E2||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                Else
-                    Write(101,'(A)') 'N1  ->  N2:  < J1      M1 || E2 ||  J2      M2>    <J1||E2||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E2 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE2 /= 0.d0) Then
@@ -2023,13 +1999,6 @@ Contains
         End If
         ! Print table for E3
         If (Keys%E3 == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(102,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E3 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||E3||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                Else
-                    Write(102,'(A)') 'N1  ->  N2:  < J1      M1 || E3 ||  J2      M2>    <J1||E3||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E3 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AE3 /= 0.d0) Then
@@ -2038,13 +2007,6 @@ Contains
         End If
         ! Print table for M1
         If (Keys%M1 == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(103,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M1 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M1||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
-                Else
-                    Write(103,'(A)') 'N1  ->  N2:  < J1      M1 || M1 ||  J2      M2>    <J1||M1||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M1 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (G /= 0.d0) Then
@@ -2058,13 +2020,6 @@ Contains
         End If
         ! Print table for M2
         If (Keys%M2 == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(104,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M2 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M2||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                Else
-                    Write(104,'(A)') 'N1  ->  N2:  < J1      M1 || M2 ||  J2      M2>    <J1||M2||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M2 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM2 /= 0.d0) Then
@@ -2073,13 +2028,6 @@ Contains
         End If
         ! Print table for M3
         If (Keys%M3 == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(105,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M3 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M3||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                Else
-                    Write(105,'(A)') 'N1  ->  N2:  < J1      M1 || M3 ||  J2      M2>    <J1||M3||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M3 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM3 /= 0.d0) Then
@@ -2088,13 +2036,6 @@ Contains
         End If
         ! Print table for EDM
         If (Keys%EDM == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(108,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || EDM || conf2' // strsp(1:nspaces02) // 'trm2>     EDM (a.u.)  EDM (Hz/e/cm)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                Else
-                    Write(108,'(A)') 'N1  ->  N2:  < J1      M1 || EDM ||  J2      M2>     EDM (a.u.)  EDM (Hz/e/cm)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| EDM ||",1X,A,2X,A,">",3X,E12.5,3X,E12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (EDM /= 0.d0 .or. EDM1 /= 0.d0) Then
@@ -2103,13 +2044,6 @@ Contains
         End If
         ! Print table for PNC
         If (Keys%PNC == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(109,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || PNC || conf2' // strsp(1:nspaces02) // 'trm2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                Else
-                    Write(109,'(A)') 'N1  ->  N2:  < J1      M1 || PNC ||  J2      M2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| PNC ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (PNC /= 0.d0 .or. PNC1 /= 0.d0) Then
@@ -2118,13 +2052,6 @@ Contains
         End If
         ! Print table for AM
         If (Keys%AM == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(110,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || AM || conf2' // strsp(1:nspaces02) // 'trm2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                Else
-                    Write(110,'(A)') 'N1  ->  N2:  < J1      M1 || AM ||  J2      M2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| AM ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM /= 0.d0 .or. AM1 /= 0.d0) Then
@@ -2133,13 +2060,6 @@ Contains
         End If
         ! Print table for MQM
         If (Keys%MQM == 1) Then
-            If (k1 == 1 .and. k2 == 1) Then
-                If (existStr == .true.) Then
-                    Write(111,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 |  MQM | conf2' // strsp(1:nspaces02) // 'trm2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                Else
-                    Write(111,'(A)') 'N1  ->  N2:  < J1      M1 || MQM ||  J2      M2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-                End If
-            End If
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| MQM ||",1X,A,2X,A,">",3X,E12.5,9X,E12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (QM /= 0.d0 .or. QM1 /= 0.d0) Then
@@ -2148,6 +2068,64 @@ Contains
         End If
         Write(6, '(A)') ' '
     End Subroutine RdcTM
+
+    Subroutine WriteHeaders
+        ! This subroutine writes the headers of specified Operator*.RES files
+        Implicit None
+        Integer :: i, nspaces01, nspaces02, nspaces1, nspaces2
+        Character(Len=128) :: strsp
+        strsp = ''
+        nspaces1 = 0
+        nspaces2 = 0
+
+        Do i=1,nterm1f-nterm1+1
+            If (len(Trim(AdjustL(strc1(i)))) > nspaces1) nspaces1 = len(Trim(AdjustL(strc1(i))))
+        End Do
+
+        Do i=1,nterm2f-nterm2+1
+            If (len(Trim(AdjustL(strc2(i)))) > nspaces2) nspaces2 = len(Trim(AdjustL(strc2(i))))
+        End Do   
+
+        nspaces01 = nspaces1-1
+        nspaces02 = nspaces2-1
+
+        If (existStr) Then
+            If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
+                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_L||J2>  <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            Else If (Keys%E1_L == 1) Then
+                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            Else If (Keys%E1_V == 1) Then
+                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            End If
+            If (Keys%E2 == 1) Write(101,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E2 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||E2||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            If (Keys%E3 == 1) Write(102,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E3 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||E3||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M1 == 1) Write(103,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M1 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M1||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
+            If (Keys%M2 == 1) Write(104,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M2 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M2||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M3 == 1) Write(105,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M3 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M3||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%EDM == 1) Write(108,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || EDM || conf2' // strsp(1:nspaces02) // 'trm2>     EDM (a.u.)  EDM (Hz/e/cm)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%PNC == 1) Write(109,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || PNC || conf2' // strsp(1:nspaces02) // 'trm2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%AM == 1) Write(110,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || AM || conf2' // strsp(1:nspaces02) // 'trm2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%MQM == 1) Write(111,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 |  MQM | conf2' // strsp(1:nspaces02) // 'trm2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+        Else
+            If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
+                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>  <J1||E1_L||J2>  <J1||E1_V||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            Else If (Keys%E1_L == 1) Then
+                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            Else If (Keys%E1_V == 1) Then
+                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            End If
+            If (Keys%E2 == 1) Write(101,'(A)') 'N1  ->  N2:  < J1      M1 || E2 ||  J2      M2>    <J1||E2||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            If (Keys%E3 == 1) Write(102,'(A)') 'N1  ->  N2:  < J1      M1 || E3 ||  J2      M2>    <J1||E3||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M1 == 1) Write(103,'(A)') 'N1  ->  N2:  < J1      M1 || M1 ||  J2      M2>    <J1||M1||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
+            If (Keys%M2 == 1) Write(104,'(A)') 'N1  ->  N2:  < J1      M1 || M2 ||  J2      M2>    <J1||M2||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M3 == 1) Write(105,'(A)') 'N1  ->  N2:  < J1      M1 || M3 ||  J2      M2>    <J1||M3||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%EDM == 1) Write(108,'(A)') 'N1  ->  N2:  < J1      M1 || EDM ||  J2      M2>     EDM (a.u.)  EDM (Hz/e/cm)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%PNC == 1) Write(109,'(A)') 'N1  ->  N2:  < J1      M1 || PNC ||  J2      M2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%AM == 1) Write(110,'(A)') 'N1  ->  N2:  < J1      M1 || AM ||  J2      M2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%MQM == 1) Write(111,'(A)') 'N1  ->  N2:  < J1      M1 || MQM ||  J2      M2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+        End If
+
+    End Subroutine
 
     Subroutine RdcDM (ntrm,k1,Etrm,Tj1,imin,imax,lf)
         ! This subroutine forms reduced density matrices from Ro
@@ -2348,7 +2326,7 @@ Contains
 
         If (Keys%GF == 1) Then
             If (ntrm == 1) Then
-                If (existStr == .true.) Then
+                If (existStr) Then
                     Write(112,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term     gfactor      E_n (a.u.)'
                 Else
                     Write(112,'(A)') ' n  J1       M1      gfactor      E_n (a.u.)'
@@ -2360,7 +2338,7 @@ Contains
 
         If (Keys%A_hf == 1) Then
             If (ntrm == 1) Then
-                If (existStr == .true.) Then
+                If (existStr) Then
                     Write(106,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term        A_hfs (MHz)         E_n (a.u.)'
                 Else
                     Write(106,'(A)') ' n  J1       M1      A_hfs (MHz)            E_n (a.u.)'
@@ -2372,7 +2350,7 @@ Contains
 
         If (Keys%B_hf == 1) Then
             If (ntrm == 1) Then
-                If (existStr == .true.) Then
+                If (existStr) Then
                     Write(107,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term        B_hfs (MHz)         E_n (a.u.)'
                 Else
                     Write(107,'(A)') ' n  J1       M1      B_hfs (MHz)            E_n (a.u.)'
@@ -2384,7 +2362,7 @@ Contains
 
         If (Keys%gQED == 1) Then
             If (ntrm == 1) Then
-                If (existStr == .true.) Then
+                If (existStr) Then
                     Write(113,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term     gQED      E_n (a.u.)'
                 Else
                     Write(113,'(A)') ' n  J1       M1      gQED      E_n (a.u.)'

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -760,7 +760,7 @@ Contains
 
     Subroutine Rint     
         Use wigner
-        ! this Subroutine calculates radial integrals for one-electron operators
+        ! this subroutine calculates radial integrals for one-electron operators
         Implicit None
         Integer :: kab, na, nb, ja, jb, la, lb, i, in, nmin, ih, k, &
                   lg, lbs, is, las, ip, jab, n12
@@ -2096,8 +2096,6 @@ Contains
             nspaces01 = nspaces1-1
             nspaces02 = nspaces2-1
         End If
-
-        
 
         If (existStr) Then
             ! TM headers

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -1429,6 +1429,7 @@ Contains
         Integer*8 :: mem, memsum, count
         Real(dp) :: tj2, bn, bk, rc, rxx, s, ms, e1, e2
         Integer, Allocatable, Dimension(:) :: idet1, idet2
+        Real(dp), Allocatable, Dimension(:) :: save_energies, save_J
         Character(Len=16)     :: memStr, npesStr, err_msg, err_msg2
 
         Allocate(idet1(Ne),idet2(Ne),iconf1(Ne),iconf2(Ne))
@@ -1440,6 +1441,9 @@ Contains
         Allocate(ArrB2(Nd2,nlvs))
         Allocate(B1(Nd1),B2(Nd2))
         Allocate(Iarr2(Ne,Nd2))
+        Allocate(save_energies(nterm1f-nterm1+1), save_J(nterm1f-nterm1+1))
+        save_energies = 0_dp
+        save_J = 0_dp
 
         If (mype==0) Then
             ! Read in determinants of CONF1.DET
@@ -1554,6 +1558,8 @@ Contains
             lf=0
             iab2=0
             l2=0
+            save_energies(n1) = e1
+            save_J(n1) = tj1
             Do n2=n21,n22
                 l2=l2+1
                 lf=lf+1
@@ -1562,8 +1568,8 @@ Contains
                 e2=e2s(iab2)
                 tj2=tj2s(iab2)
 
-                ! Skip transition if states/energies are the same
-                If (e1 == e2 .and. tj1 == tj2) Cycle
+                ! Skip transition if state2 == state1, or state2 <-> state1 has already been accounted for
+                If (any(save_energies == e2) .and. any(save_J == tj2)) Cycle
                 
                 If (dabs(tj2-tj1) < 3.1d0) Then
                     Ro=0.d0

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -617,7 +617,7 @@ Contains
         Integer, Allocatable, Dimension(:) :: Intg2
         Real (dp), Allocatable, Dimension(:) :: Rnt2
         Integer, Dimension(13) :: ki, ki2
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         Nsu=0              !### Nsu is used to eliminate integrals
         Do i=Nso+1,Nsp
             is=Nip(i)
@@ -682,7 +682,7 @@ Contains
         End If
 
         Return
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
 200     Open(13,file='DTM.INT',status='UNKNOWN',form='UNFORMATTED')
         Close(13,status='DELETE')
         Call Rint
@@ -767,7 +767,7 @@ Contains
         Real(dp) :: x, c3, s1, s2, w1, w2, w3, ga, gb, gab, dn, tab, Alfd, qe
         Real(dp), Dimension(IP6)  :: p, q, a, b, ro
         Real(dp), Dimension(10) :: rcut
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         MaxT=9     !## Max power in Taylor expansion at the origin
         If (Rnuc == 0.d0) Rnuc = 1.2D-13/0.529D-8*Anuc**0.33333d0
         !  >>>>>>>>>>>>>> ECP of the core <<<<<<<<<<<<<<<<<<
@@ -1025,7 +1025,7 @@ Contains
                 End If
             End Do
         End Do
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         Write( 6,'(4X,"Nint=",I7," Nsu=",I3)') Nint,Nsu
         Write(11,'(4X,"Nint=",I7," Nsu=",I3)') Nint,Nsu
         Close(12)
@@ -1039,12 +1039,12 @@ Contains
         Real(dp) :: R1, R2, R3, T1, T2, F1, F2, F3, F21, F32, F321, &
                     C0, C1, C2, G, P1, P2, T, Q, HH, Gam
         Real(dp), intent(out) :: DS
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         Gam=C(ii+4)
         IH=2-KT
         HH=H*IH/3.d0
         I0=IH+1
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         I1=1
         I2=I1+IH
         I3=I2+IH
@@ -1089,7 +1089,7 @@ Contains
         Implicit None
         Integer :: nna, na, la, ja, nnb, lb, jb, ir, nab1, nb
         Real(dp) :: dn, tab
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         nna=Nn(na)
         la=Ll(na)
         ja=Jj(na)
@@ -1715,6 +1715,7 @@ Contains
         Integer, Dimension(3*IPx) :: ind
         Integer, Dimension(IPx) :: i1, i2
         Character(Len=512) :: strfmt, strsp
+        
         ! tj1,tj2,tm1,Tm2 - TOTAL MOMENTA AND THEIR PROJECTIONS.
         imin1=imin+Npo
         imax1=imax+Npo
@@ -1753,7 +1754,7 @@ Contains
             Write (11,'(10(3X,I2,3X))') (i2(k)-i1(k)+1,k=1,kmax)
             Write (11,'(10(1X,3I2,1X))') (ind(k),ind(k+IPx),ind(k+2*IPx),k=1,kmax)
         End If
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         ppl = 0.d0 !###  ppl  = TRACE OF TM,
         AE1 = 0.d0 !###  AE1  = REDUCED E1 AMPLITUDE IN L GAUGE
         AE1V= 0.d0 !###  AE1V = REDUCED E1 AMPLITUDE IN V GAUGE
@@ -2074,22 +2075,32 @@ Contains
         Implicit None
         Integer :: i, nspaces01, nspaces02, nspaces1, nspaces2
         Character(Len=128) :: strsp
+
         strsp = ''
         nspaces1 = 0
         nspaces2 = 0
 
-        Do i=1,nterm1f-nterm1+1
-            If (len(Trim(AdjustL(strc1(i)))) > nspaces1) nspaces1 = len(Trim(AdjustL(strc1(i))))
-        End Do
+        If (Kl1 == 1) Then
+            Do i=1,nterm2-nterm1+1
+                If (len(Trim(AdjustL(strc1(i)))) > nspaces1) nspaces1 = len(Trim(AdjustL(strc1(i))))
+            End Do
+        Else If (Kl1 == 2) Then
+            Do i=1,nterm1f-nterm1+1
+                If (len(Trim(AdjustL(strc1(i)))) > nspaces1) nspaces1 = len(Trim(AdjustL(strc1(i))))
+            End Do
 
-        Do i=1,nterm2f-nterm2+1
-            If (len(Trim(AdjustL(strc2(i)))) > nspaces2) nspaces2 = len(Trim(AdjustL(strc2(i))))
-        End Do   
+            Do i=1,nterm2f-nterm2+1
+                If (len(Trim(AdjustL(strc2(i)))) > nspaces2) nspaces2 = len(Trim(AdjustL(strc2(i))))
+            End Do
 
-        nspaces01 = nspaces1-1
-        nspaces02 = nspaces2-1
+            nspaces01 = nspaces1-1
+            nspaces02 = nspaces2-1
+        End If
+
+        
 
         If (existStr) Then
+            ! TM headers
             If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
                 Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_L||J2>  <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
             Else If (Keys%E1_L == 1) Then
@@ -2106,7 +2117,14 @@ Contains
             If (Keys%PNC == 1) Write(109,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || PNC || conf2' // strsp(1:nspaces02) // 'trm2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
             If (Keys%AM == 1) Write(110,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || AM || conf2' // strsp(1:nspaces02) // 'trm2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
             If (Keys%MQM == 1) Write(111,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 |  MQM | conf2' // strsp(1:nspaces02) // 'trm2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+
+            ! DM headers
+            If (Keys%GF == 1) Write(112,'(A)') ' n   conf' // strsp(1:nspaces1) // 'term     gfactor      E_n (a.u.)'
+            If (Keys%gQED == 1) Write(113,'(A)') ' n   conf' // strsp(1:nspaces1) // 'term     gQED      E_n (a.u.)'
+            If (Keys%A_hf == 1) Write(106,'(A)') ' n   conf' // strsp(1:nspaces1) // 'term        A_hfs (MHz)         E_n (a.u.)'
+            If (Keys%B_hf == 1) Write(107,'(A)') ' n   conf' // strsp(1:nspaces1) // 'term        B_hfs (MHz)         E_n (a.u.)'
         Else
+            ! TM headers
             If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
                 Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>  <J1||E1_L||J2>  <J1||E1_V||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
             Else If (Keys%E1_L == 1) Then
@@ -2123,6 +2141,11 @@ Contains
             If (Keys%PNC == 1) Write(109,'(A)') 'N1  ->  N2:  < J1      M1 || PNC ||  J2      M2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
             If (Keys%AM == 1) Write(110,'(A)') 'N1  ->  N2:  < J1      M1 || AM ||  J2      M2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
             If (Keys%MQM == 1) Write(111,'(A)') 'N1  ->  N2:  < J1      M1 || MQM ||  J2      M2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            ! DM headers
+            If (Keys%GF == 1) Write(112,'(A)') ' n  J1       M1      gfactor      E_n (a.u.)'
+            If (Keys%gQED == 1) Write(113,'(A)') ' n  J1       M1      gQED      E_n (a.u.)'
+            If (Keys%A_hf == 1) Write(106,'(A)') ' n  J1       M1      A_hfs (MHz)            E_n (a.u.)'
+            If (Keys%B_hf == 1) Write(107,'(A)') ' n  J1       M1      B_hfs (MHz)            E_n (a.u.)'
         End If
 
     End Subroutine
@@ -2142,10 +2165,10 @@ Contains
         Real(dp), Dimension(IPx) :: pp
         Integer, Dimension(IPx) :: npp, lpp
         Character(Len=256) :: strfmt, strsp
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         imin1=imin+Npo
         imax1=imax+Npo
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         tj=Tj1        !### tj and tm -total momentum and its projection
         jt=tj+tj+0.1d0
         tj=jt/2.d0
@@ -2160,7 +2183,8 @@ Contains
         ! EACH SHELL ONLY Q.N. Jz CHANGES. k IS INDEX OF A SHELL
         k=0
         i=imin1
-500     k=k+1
+        Do While (i < imax1)
+            k=k+1
             no=Nh(i)
             ind(k)=Nn(no)
             ind(k+IPx)=Ll(no)
@@ -2170,7 +2194,7 @@ Contains
             i2(k)=i+(Jj(no)-Jz(i))/2
             If (i2(k) > imax1) i2(k)=imax1
             i=i2(k)+1
-        If (i < imax1) Goto 500
+        End Do
         kmax=k
         If (kmax > IPx) Then
             Write(*,*)' Dimension of reduced DM =',kmax,' > ',IPx
@@ -2181,7 +2205,7 @@ Contains
             Write (11,'(10(3X,I2,3X))') (i2(k)-i1(k)+1,k=1,kmax)
             Write (11,'(10(1X,3I2,1X))') (ind(k),ind(k+IPx),ind(k+2*IPx),k=1,kmax)
         End If
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         ppl=0.d0        !### = NUMBER OF ELECTRONS,
         G=0.d0          !### = G-FACTOR,
         A=0.d0          !### A,B - HFS CONSTANTS
@@ -2190,7 +2214,7 @@ Contains
         lk0=-1          ! lk0,nk0,ipp,xpp used to calculate
         nk0=-1          !!  occupation numbers for n,l shells
         ipp=0
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         Do l1=1,3       !### loop for ranks 0,1,2:
             tl=l1-1
             c=Isgn((jt-mj)/2) * Fj3(tj,tl,tj,-tm,0.d0,tm)
@@ -2325,49 +2349,21 @@ Contains
         nspaces1 = nspaces1 - len(Trim(AdjustL(strc1(k1))))
 
         If (Keys%GF == 1) Then
-            If (ntrm == 1) Then
-                If (existStr) Then
-                    Write(112,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term     gfactor      E_n (a.u.)'
-                Else
-                    Write(112,'(A)') ' n  J1       M1      gfactor      E_n (a.u.)'
-                End If
-            End If
             strfmt = '(I2,2X,A,3X,A,4X,F8.5,5X,F10.5)'
             Write(112,strfmt) k1, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), G, Etrm
         End If
 
         If (Keys%A_hf == 1) Then
-            If (ntrm == 1) Then
-                If (existStr) Then
-                    Write(106,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term        A_hfs (MHz)         E_n (a.u.)'
-                Else
-                    Write(106,'(A)') ' n  J1       M1      A_hfs (MHz)            E_n (a.u.)'
-                End If
-            End If
             strfmt = '(I2,2X,A,3X,A,4X,E15.8,8X,F10.5)'
             Write(106,strfmt) k1, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), A, Etrm
         End If
 
         If (Keys%B_hf == 1) Then
-            If (ntrm == 1) Then
-                If (existStr) Then
-                    Write(107,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term        B_hfs (MHz)         E_n (a.u.)'
-                Else
-                    Write(107,'(A)') ' n  J1       M1      B_hfs (MHz)            E_n (a.u.)'
-                End If
-            End If
             strfmt = '(I2,2X,A,3X,A,4X,E15.8,8X,F10.5)'
             Write(107,strfmt) k1, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), B, Etrm
         End If
 
         If (Keys%gQED == 1) Then
-            If (ntrm == 1) Then
-                If (existStr) Then
-                    Write(113,'(A)') ' n   conf' // strsp(1:nspaces0) // 'term     gQED      E_n (a.u.)'
-                Else
-                    Write(113,'(A)') ' n  J1       M1      gQED      E_n (a.u.)'
-                End If
-            End If
             strfmt = '(I2,2X,A,3X,A,4X,F8.5,5X,F10.5)'
             Write(113,strfmt) k1, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), gQ, Etrm
         End If
@@ -2376,12 +2372,12 @@ Contains
     End Subroutine RdcDM
 
     Subroutine DM_out(ntrm,kmax,ind,i1)  
-        ! this Subroutine opens the file DM0.RES and Writes Rro
+        ! this subroutine opens the file DM0.RES and Writes Rro
         Implicit None
         Integer :: ntrm, kmax, k, i
         Integer, Dimension(3*IPx) :: ind
         Integer, Dimension(IPx) :: i1, no
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         If (Kdm < 1) Return
         If (Kdm == 1) Then
             Kdm=2

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -1956,7 +1956,6 @@ Contains
                 Else
                     tr = (2.02613e18/((2*tj2+1)*(wl*10)**3))*AE1**2
                 End If
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AE1, AE1V, -e1, -e2, -delEcm, wl
                 Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1, AE1V, -e1, -e2, -delEcm, wl, tr
             End If
         ! Print table for E1_L
@@ -1976,7 +1975,6 @@ Contains
                 Else
                     tr = (2.02613e18/((2*tj2+1)*(wl*10)**3))*AE1**2
                 End If
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AE1, -e1, -e2, -delEcm, wl
                 Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1, -e1, -e2, -delEcm, wl, tr
             End If
         ! Print table for E1_V
@@ -1996,7 +1994,6 @@ Contains
                 Else
                     tr = (2.02613e18/((2*tj2+1)*(wl*10)**3))*AE1V**2
                 End If
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AE1V, -e1, -e2, -delEcm, wl
                 Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1V, -e1, -e2, -delEcm, wl, tr
             End If
         End If
@@ -2017,8 +2014,7 @@ Contains
                 Else
                     tr = (1.11995e18/((2*tj2+1)*(wl*10)**5))*AE2**2
                 End If
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AE2, -e1, -e2, -delEcm, wl
-                Write(101,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE2, -e1, -e2, -delEcm, wl, tr
+                If (n2 > n1) Write(101,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE2, -e1, -e2, -delEcm, wl, tr
             End If
         End If
         ! Print table for E3
@@ -2033,7 +2029,6 @@ Contains
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E3 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AE3 /= 0.d0) Then
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AE3, -e1, -e2, -delEcm, wl
                 Write(102,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE3, -e1, -e2, -delEcm, wl
             End If
         End If
@@ -2054,8 +2049,7 @@ Contains
                 Else
                     tr = (2.69735e13/((2*tj2+1)*(wl*10)**3))*G**2
                 End If
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), G, -e1, -e2, -delEcm, wl
-                Write(103,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), G, -e1, -e2, -delEcm, wl, tr
+                If (n2 > n1) Write(103,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), G, -e1, -e2, -delEcm, wl, tr
             End If
         End If
         ! Print table for M2
@@ -2070,7 +2064,6 @@ Contains
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M2 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM2 /= 0.d0) Then
-                !Write(  6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AM2, -e1, -e2, -delEcm, wl
                 Write(104,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM2, -e1, -e2, -delEcm, wl
             End If
         End If
@@ -2086,8 +2079,7 @@ Contains
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M3 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM3 /= 0.d0) Then
-                !Write(  6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AM3, -e1, -e2, -delEcm, wl
-                Write(105,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM3, -e1, -e2, -delEcm, wl
+                If (n2 > n1) Write(105,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM3, -e1, -e2, -delEcm, wl
             End If
         End If
         ! Print table for EDM
@@ -2102,7 +2094,6 @@ Contains
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| EDM ||",1X,A,2X,A,">",3X,E12.5,3X,E12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (EDM /= 0.d0 .or. EDM1 /= 0.d0) Then
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), EDM, EDM1, -e1, -e2, -delEcm, wl
                 Write(108,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), EDM, EDM1, -e1, -e2, -delEcm, wl
             End If
         End If
@@ -2118,7 +2109,6 @@ Contains
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| PNC ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (PNC /= 0.d0 .or. PNC1 /= 0.d0) Then
-                !Write(  6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), PNC, PNC1, -e1, -e2, -delEcm, wl
                 Write(109,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), PNC, PNC1, -e1, -e2, -delEcm, wl
             End If
         End If
@@ -2134,7 +2124,6 @@ Contains
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| AM ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM /= 0.d0 .or. AM1 /= 0.d0) Then
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), AM, AM1, -e1, -e2, -delEcm, wl
                 Write(110,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM, AM1, -e1, -e2, -delEcm, wl
             End If
         End If
@@ -2150,7 +2139,6 @@ Contains
             strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| MQM ||",1X,A,2X,A,">",3X,E12.5,9X,E12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (QM /= 0.d0 .or. QM1 /= 0.d0) Then
-                !Write( 6,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), strt1(k1), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), strt2(k2), QM, QM1, -e1, -e2, -delEcm, wl
                 Write(111,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), QM, QM1, -e1, -e2, -delEcm, wl
             End If
         End If

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -1346,8 +1346,6 @@ Contains
         ! - - - - - - - - - - - - - - - - - - - - - - - - -
 700     Write (*,*) 'FormDM: norma for vector ',ntr,' is ',s
         Return
-710     Write (*,*) 'FormDM: index out of range (IP1<imax):'
-        Write (*,*) 'IP1=',IP1,' imax=',imax,' n=',n
         Return
     End Subroutine FormDM
 
@@ -1614,10 +1612,6 @@ Contains
                                                 imax=max(imax,j1,j2)
                                                 imin=min(imin,j1,j2)
                                                 Ro(j1,j2)=Ro(j1,j2)+bn*bk*is
-                                            End If
-                                            If (imax > IP1) Then
-                                                Write(*,*) imax,'= imax > IP1 =',IP1
-                                                Stop
                                             End If
                                         End If
                                     End Do

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -1564,6 +1564,10 @@ Contains
                 B2(1:Nd2)=ArrB2(1:Nd2,iab2)
                 e2=e2s(iab2)
                 tj2=tj2s(iab2)
+
+                ! Skip transition if states/energies are the same
+                If (e1 == e2 .and. tj1 == tj2) Cycle
+                
                 If (dabs(tj2-tj1) < 3.1d0) Then
                     Ro=0.d0
                     imax=0


### PR DESCRIPTION
- refactored IP1 parameter out of pdtm.f90 and removed IP1 array size warnings
- fixed formatting of Operator.RES files produced by pdtm
- pdtm now skips transitions that have already been accounted for, e.g. b -> a is skipped if a -> b was done
- introduced AllReduceD subroutine in mpi_utils.f90 to handle MPI_AllReduce for double precision
- updated theory_lifetimes.py script to handle multiple input files
- updated gen_job_script.py script to use scontrol show config to determine cluster information if using SLURM
- fixed bug in reading K_sms
- optimized gQED calculation