### PR TITLE
gfortran compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2024-12-13
+- refactored main programs for gfortran compatibility
+- check_matrices.f90 - small new program check_matrices to check for errors in CONFp.HIJ and CONFp.JJJ
+- updated matrix_io.f90 to use mpi_f08
+- pconf.f90 -> pconf.F90, use preprocessing directives to compile ScaLAPACK routines
+- pconf - fixed allocation of array E for LAPACK subroutines
+- removed IPmr parameter from params.f90 and refactored IPmr-associated arrays
+
 ## [1.0.7] - 2024-11-17
 - refactored IP1 parameter out of pdtm.f90 and removed IP1 array size warnings
 - fixed formatting of Operator.RES files produced by pdtm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,21 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 
 project(pci 
-        VERSION 1.0.7
+        VERSION 1.1.0
         DESCRIPTION "pCI software package"
         LANGUAGES Fortran)
 include(GNUInstallDirs)
 
-# Need Intel Fortran compiler
-if (NOT ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" AND NOT ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM")
-    message(FATAL_ERROR "Intel Fortran compiler (ifort or ifx) not found. Please ensure FC is set to 'ifort' or 'ifx'.")
-else()
+# Need a Fortran compiler
+if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM")
     message(STATUS "Intel Fortran compiler found: ${CMAKE_Fortran_COMPILER}")
     message(STATUS "Intel Fortran compiler: ${CMAKE_Fortran_COMPILER_ID}")
+elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
+    message(STATUS "GNU Fortran compiler found: ${CMAKE_Fortran_COMPILER}")
+    message(STATUS "GNU Fortran compiler: ${CMAKE_Fortran_COMPILER_ID}")
+    message(WARNING "Optional programs for QED and all-order are not compilable with gfortran")
+else()
+    message(FATAL_ERROR "Intel or GNU Fortran compiler was not detected.")
 endif()
 
 # Need MPI
@@ -27,6 +31,43 @@ else()
     message(FATAL_ERROR "OpenMPI not detected. Please ensure OpenMPI is installed and loaded, and that mpifort points to the OpenMPI version.")
 endif()
 
+# Need BLAS and LAPACK
+# Find MKL
+find_package(MKL QUIET)
+if (MKL_FOUND)
+    message(STATUS "MKL libary detected: ${MKL_LIBRARIES}")
+else()
+    # If find_package can't find MKL, manually check for MKL
+    set(MKL_ROOT $ENV{MKLROOT})
+    
+    if (MKL_ROOT)
+        set(MKL_INCLUDE_DIR "${MKL_ROOT}/include")
+        set(MKL_LIB_DIR "${MKL_ROOT}/lib/intel64")
+        message(STATUS "MKL library detected: ${MKL_LIB_DIR}")
+    else()
+        message(STATUS "MKL library not detected. Falling back to BLAS and LAPACK.")
+
+        # Find BLAS and LAPACK
+        find_package(BLAS REQUIRED)
+        find_package(LAPACK REQUIRED)
+        if (BLAS_FOUND AND LAPACK_FOUND)
+            message(STATUS "BLAS library detected: ${BLAS_LIBRARIES}")
+            message(STATUS "LAPACK library detected: ${LAPACK_LIBRARIES}")
+        else()
+            message(FATAL_ERROR "BLAS and LAPACK not detected. Please ensure BLAS and LAPACK are installed.")
+        endif()
+
+        # Find ScaLAPACK
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+        find_package(ScaLAPACK QUIET)
+        if (ScaLAPACK_FOUND)
+            message(STATUS "ScaLAPACK detected: ${ScaLAPACK_LIBRARIES}")
+        else()
+            message(FATAL_ERROR "ScaLAPACK not detected.")
+        endif()
+    endif()
+endif()
+
 # Add default Intel compile/link flags:
 if (${CMAKE_Fortran_COMPILER} MATCHES "ifort")
     set(MKL_PARALLEL_FLAGS -qopenmp -mkl=parallel)
@@ -38,6 +79,9 @@ elseif (${CMAKE_Fortran_COMPILER} MATCHES "ifx")
     set(MKL_PARALLEL_LINK_FLAGS -qopenmp -qmkl=parallel -lmkl_scalapack_lp64 -lmkl_blacs_openmpi_lp64)
     add_compile_options(-qopenmp -qmkl=sequential)
     add_link_options(-qopenmp -qmkl=sequential -lmkl_scalapack_lp64 -lmkl_blacs_openmpi_lp64)
+elseif (${CMAKE_Fortran_COMPILER} MATCHES "gfortran")
+    add_compile_options(-fopenmp -lscalapack -lblas -llapack)
+    add_link_options(-fopenmp -lscalapack -lblas -llapack)
 endif()
 # The FindMPI returns linker flags as a space-delimited string, but target_link_options() needs a list:
 string(REGEX REPLACE "[ \t\r\n]" ";" MPI_Fortran_LINK_FLAGS "${MPI_Fortran_LINK_FLAGS}")

--- a/cmake/modules/FindScaLAPACK.cmake
+++ b/cmake/modules/FindScaLAPACK.cmake
@@ -1,0 +1,41 @@
+# CMake "find module" for ScaLAPACK. Even though reference ScaLAPACK
+# provides a CMake config file, the Intel MKL version of ScaLAPACK
+# does not. This CMake find module can be bypassed in favor of
+# detecting the reference ScaLAPACK find module via setting
+# CMAKE_FIND_PACKAGE_PREFER_CONFIG to TRUE.
+
+# General strategy:
+#
+# 1) Easiest: check to see if reference ScaLAPACK installed.
+#
+# 2) Check to see if PBLAS is needed. (If it is, fail for now, then
+# implement a FindPBLAS.cmake later on.)
+#
+# 3) Check to see if BLACS is needed. (If it is, fail for now, then
+# implement a FindBLACS.cmake later on.)
+#
+# 4) Probably need to implement the basics of a FindMKL.cmake package.
+#
+
+# Search hardcoded paths as follows:
+# - /usr/lib64 and /usr/lib for system-wide Linux/BSD installation via system
+#   package manager
+# - /usr/local/lib64 and /usr/local/lib for system-wide Linux/BSD installation
+#    outside of system package manager; includes Homebrew
+# - /opt/local for MacPorts installation
+# - /sw/lib or /opt/sw/lib for Fink installation
+find_library(ScaLAPACK_LIBRARY
+  NAMES scalapack scalapack-mpi scalapack-mpich scalapack-mpich2 scalapack-openmpi
+  PATHS /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib
+  /opt/local/lib /opt/sw/lib /sw/lib
+  ENV LD_LIBRARY_PATH
+  ENV DYLD_FALLBACK_LIBRARY_PATH
+  ENV DYLD_LIBRARY_PATH
+  ENV SCALAPACKDIR
+  ENV BLACSDIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ScaLAPACK
+  REQUIRED_VARS ScaLAPACK_LIBRARY
+  )
+set(ScaLAPACK_LIBRARIES ${ScaLAPACK_LIBRARY})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(hfd PUBLIC pci_common)
 ADD_EXECUTABLE(bass bass.f90)
 target_link_libraries(bass PUBLIC pci_common)
 
-ADD_EXECUTABLE(add params.f90 vaccumulator.f90 add.f90)
+ADD_EXECUTABLE(add params.f90 add.f90)
 target_link_libraries(add PUBLIC pci_common)
 
 ADD_EXECUTABLE(pbasc pbasc.f90)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(pbasc PUBLIC ${MPI_Fortran_INCLUDE_DIRS})
 target_link_options(pbasc PUBLIC ${MPI_Fortran_LINK_FLAGS})
 target_link_libraries(pbasc PUBLIC ${MPI_Fortran_LIBRARIES} pci_common)
 
-ADD_EXECUTABLE(pconf env_var.f90 matrix_io.f90 vaccumulator.f90 formj2.f90 davidson.f90 pconf.f90)
+ADD_EXECUTABLE(pconf env_var.f90 matrix_io.f90 vaccumulator.f90 formj2.f90 davidson.f90 pconf.F90)
 target_compile_definitions(pconf PUBLIC ${MPI_Fortran_COMPILE_DEFINITIONS})
 target_compile_options(pconf PUBLIC ${MPI_Fortran_COMPILE_OPTIONS})
 target_include_directories(pconf PUBLIC ${MPI_Fortran_INCLUDE_DIRS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,8 @@ target_link_libraries(pdtm PUBLIC ${MPI_Fortran_LIBRARIES} pci_common)
 ADD_EXECUTABLE(sort str_fmt.f90 sort.f90)
 target_link_libraries(sort PUBLIC pci_common)
 
+ADD_EXECUTABLE(check_matrices check_matrices.f90)
+
 ADD_EXECUTABLE(ine ine.f90)
 target_link_options(ine PRIVATE ${MKL_PARALLEL_LINK_FLAGS})
 target_link_libraries(ine PRIVATE ${MKL_PARALLEL_LINK_FLAGS} pci_common)
@@ -70,4 +72,4 @@ target_include_directories(formy PUBLIC ${MPI_Fortran_INCLUDE_DIRS})
 target_link_options(formy PUBLIC ${MPI_Fortran_LINK_FLAGS})
 target_link_libraries(formy PUBLIC ${MPI_Fortran_LIBRARIES} pci_common)
 
-INSTALL(TARGETS hfd bass add pbasc pconf conf_lsj pdtm ine pol conf_pt sort formy DESTINATION ${CMAKE_INSTALL_BINDIR})
+INSTALL(TARGETS hfd bass add pbasc pconf conf_lsj pdtm ine pol conf_pt sort check_matrices formy DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ ADD_EXECUTABLE(sort str_fmt.f90 sort.f90)
 target_link_libraries(sort PUBLIC pci_common)
 
 ADD_EXECUTABLE(check_matrices check_matrices.f90)
+target_link_libraries(check_matrices PUBLIC pci_common)
 
 ADD_EXECUTABLE(ine ine.f90)
 target_link_options(ine PRIVATE ${MKL_PARALLEL_LINK_FLAGS})

--- a/src/add.f90
+++ b/src/add.f90
@@ -253,7 +253,7 @@ Contains
         ! Expand the list of non-relativistic configurations into a list of relativistic configurations
         Implicit None
         Integer :: ic, icnr, kc, ji, k, n, jk, i, nx, mx, mmax1, mmax2, mmin1, m1, k1, ivar, irmax, k1max
-        Integer :: j, ir, j1, l, iq1, iq2, idif, ncr, jkmax, nozmax, num_rel_confs
+        Integer :: j, ir, j1, l, iq1, iq2, idif, ncr, jkmax, nozmax, num_rel_confs, num_rel_confs0
         Real(dp) :: qnl
         Integer, Allocatable, Dimension(:)  :: nyi, myi, nyk, myk, ivc, ni, li, iv, NozN, temp
         Integer, Allocatable, Dimension(:, :)   :: mx1, mx2, ivv
@@ -317,11 +317,12 @@ Contains
         If (.not. Allocated(mx2)) Allocate(mx2(nozmax, k1max))
 
         ! Reallocate Ac, NOz
+        num_rel_confs0 = size(NOz)
         Call move_alloc(Ac, temp2)
         Call move_alloc(NOz, temp)
         Allocate(NOz(num_rel_confs), Ac(num_rel_confs, max_num_shells))
-        NOz(1:num_rel_confs) = temp
-        Ac(1:num_rel_confs,1:max_num_shells) = temp2
+        NOz(1:num_rel_confs0) = temp
+        Ac(1:num_rel_confs0,1:max_num_shells) = temp2
         Deallocate(temp, temp2)
 
         ! Loop over non-relativistic configurations
@@ -651,7 +652,7 @@ Contains
         New=.FALSE.
   
         Do j=1,noz1                  !### check of the Pauli principle:
-            i1=sign(1.01,Ac1(j))     !#### nq.LE.(4*l+2)
+            i1=sign(1.01_dp,Ac1(j))     !#### nq.LE.(4*l+2)
             d=abs(Ac1(j))+1.E-6
             d=10*d
             nnj=d
@@ -664,7 +665,7 @@ Contains
         End Do
 
         Do j=1,noz1                  ! does this config.
-            i1=sign(1.01,Ac1(j))     !  belong to RAS?
+            i1=sign(1.01_dp,Ac1(j))     !  belong to RAS?
             d=abs(Ac1(j))+1.E-6
             d=10*d
             nnj=d

--- a/src/add.f90
+++ b/src/add.f90
@@ -12,7 +12,7 @@ Program add
     Real(dp), Allocatable, Dimension(:) :: V, Nqmin, Nqmax
 
     ! Print program header
-    strfmt = '(/4X,"PROGRAM add v3.0"/)'
+    strfmt = '(/4X,"PROGRAM add v3.1"/)'
     Write(6, strfmt)
 
     ! Read inputs from ADD.INP

--- a/src/basc_variables.f90
+++ b/src/basc_variables.f90
@@ -1,7 +1,8 @@
 Module basc_variables
 
-    Use params, ipmr1 => IPmr
-    Use conf_variables, Only : Ecore, Rint1, Iint1, IntOrd, Rint2, Iint2, Iint3, R_is, I_is, In, Gnt, Nlx, num_gaunts_per_partial_wave, Ngint
+    Use params
+    Use conf_variables, Only : Ecore, Rint1, Iint1, IntOrd, Rint2, Iint2, Iint3, &
+                                R_is, I_is, In, Gnt, Nlx, num_gaunts_per_partial_wave, Ngint
 
     Implicit None
 

--- a/src/bass.f90
+++ b/src/bass.f90
@@ -248,7 +248,7 @@ Contains
 
         data str1,str2,str3 /'   DF','Brcnr','Breit','Br+Bt',' NO','YES','YES','E = V = 0','E=0, V_c ','E_hf, V_c'/
 
-        strfmt = '(/4X,"Program Bass v1.2")'
+        strfmt = '(/4X,"Program Bass v1.3")'
         write( *,strfmt)
         write(11,strfmt)
 

--- a/src/check_matrices.f90
+++ b/src/check_matrices.f90
@@ -1,0 +1,50 @@
+program check_matrices
+    use, intrinsic :: iso_fortran_env, only : dp => real64, int64
+
+    implicit none
+
+    character(len=16) :: filename
+
+    print*, 'Enter matrix file (CONFp.HIJ or CONFp.JJJ) to check: '
+    read(*, *) filename
+    call read_matrix(filename)
+
+contains
+
+    subroutine read_matrix(filename)
+        ! read matrix element file written by pconf program using a single process
+        implicit none
+
+        character(len=*), intent(in) :: filename
+        integer(kind=int64) :: num_total_elements, num_zeros
+
+        integer(kind=int64) :: i
+        integer :: n, err_stat, num_procs, num_elements
+        character(len=16) :: err_msg, count_str
+        logical :: found_zero
+        
+        ! Read num_cores
+        open(unit=15,file='nprocs.conf',status='UNKNOWN',form='unformatted',access='stream',iostat=err_stat,iomsg=err_msg)
+        read(15) num_procs
+        close(15)
+    
+        Write(count_str, '(I4)') num_procs
+        print*, 'Number of processes used to write ', trim(adjustl(filename)), ': ', trim(adjustl(count_str))
+
+        open(unit=15,file=filename,status='OLD',form='unformatted',access='stream',iostat=err_stat,iomsg=err_msg)
+        num_total_elements = 0_int64
+        found_zero = .false.
+        do n = 1, num_procs
+            read(15) num_elements
+            if (num_elements == 0) then
+                print*, 'core', n-1, 'has 0 matrix elements!'
+                found_zero = .true.
+            end if
+            num_total_elements = num_total_elements + num_elements
+        end do
+        print*, 'Number of matrix elements in ', filename, ':', num_total_elements
+        if (found_zero) print*, 'WARNING: check results of pconf to see if number of matrix elements match'
+
+    end subroutine read_matrix
+
+end program check_matrices

--- a/src/conf_init.f90
+++ b/src/conf_init.f90
@@ -153,7 +153,7 @@ Module conf_init
         equals_in_str = .true.
         Do While (equals_in_str)
             Read(99, '(A)', iostat=err_stat) line
-            If (index(string=line, substring="=") == 0 .or. err_stat) Then
+            If (index(string=line, substring="=") == 0 .or. err_stat /= 0) Then
                 equals_in_str = .false.
             Else
                 index_equals = index(string=line, substring="=")
@@ -208,9 +208,9 @@ Module conf_init
     Subroutine ReadConfInp
         ! This subroutine reads input parameters from the header of CONF.INP
         Implicit None
-        Integer :: istr
+        
         Character(Len=1) :: name(16)
-        ! - - - - - - - - - - - - - - - - - - - - - -
+
         ! Optional parameters
         K_is = 0 
         C_is = 0.d0 
@@ -268,8 +268,6 @@ Module conf_init
         Implicit None
         Integer  :: i, i1, i2, ic, ne0, nx, ny, nz
         Real(dp) :: x
-        logical  :: equals_in_str
-        ! - - - - - - - - - - - - - - - - - - - - - -
         
         Call calcNsp
         Call GotoConfigurations
@@ -290,8 +288,8 @@ Module conf_init
                 Do i=i1,i2
                    x=abs(Qnl(i))+1.d-9
                    If (x < 1.d-8) Exit
-                   nx=10000*x
-                   ny=100*x
+                   nx=Int(10000*x)
+                   ny=Int(100*x)
                    nz=(nx-100*ny)
                    ne0=ne0+nz
                    If (mod(ny,10) > Nlx) Nlx=mod(ny,10) ! Set Nlx to be max partial wave
@@ -340,8 +338,8 @@ Module conf_init
                 Do i=1,num_orbitals_per_line
                    x=abs(line(i))+1.d-9
                    If (x < 1.d-8) Exit
-                   nx=10000*x
-                   ny=100*x
+                   nx=Int(10000*x)
+                   ny=Int(100*x)
                    nz=(nx-100*ny)
                    ne0=ne0+nz
                    counter = counter + 1

--- a/src/conf_lsj.f90
+++ b/src/conf_lsj.f90
@@ -81,9 +81,9 @@ Contains
         open(unit=11,status='UNKNOWN',file='CONF_LSJ.RES')
         Select Case(type2_real)
         Case(sp)
-            strfmt = '(4X,"Program conf_lsj v2.4")'
+            strfmt = '(4X,"Program conf_lsj v2.5")'
         Case(dp)            
-            strfmt = '(4X,"Program conf_lsj v2.4 with double precision for 2e integrals")'
+            strfmt = '(4X,"Program conf_lsj v2.5 with double precision for 2e integrals")'
         End Select
         Write( 6,strfmt)
         Write(11,strfmt)

--- a/src/conf_lsj.f90
+++ b/src/conf_lsj.f90
@@ -16,12 +16,21 @@ Program conf_lsj
     Character(Len=255)  :: eValue
     Character(Len=16)   :: timeStr
 
+    Type(MPI_Datatype) :: mpi_type2_real
+
     ! Initialize MPI
     Call MPI_Init(mpierr)
     Call MPI_Comm_rank(MPI_COMM_WORLD, mype, mpierr)
     Call MPI_Comm_size(MPI_COMM_WORLD, npes, mpierr)
 
     Call startTimer(start_time)
+
+    Select Case(type2_real)
+    Case(sp)
+        mpi_type2_real = MPI_REAL
+    Case(dp)
+        mpi_type2_real = MPI_DOUBLE_PRECISION
+    End Select
 
     ! Read total memory per core from environment 
     ! Have to export CONF_MAX_BYTES_PER_CPU before job runs
@@ -46,11 +55,11 @@ Program conf_lsj
     ! Print table of final results and total computation time
     If (mype==0) Then
         Call stopTimer(s1, timeStr)
-        Write(*,'(2X,A)'), 'LSJ done in '// trim(timeStr)
+        Write(*,'(2X,A)') 'LSJ done in '// trim(timeStr)
         Call PrintLSJ   !#   Output of the results
 
         Call stopTimer(start_time, timeStr)
-        write(*,'(2X,A)'), 'TIMING >>> Total computation time of conf_lsj was '// trim(timeStr)
+        write(*,'(2X,A)') 'TIMING >>> Total computation time of conf_lsj was '// trim(timeStr)
     End If
 
     Call MPI_Finalize(mpierr)
@@ -99,6 +108,7 @@ Contains
     End Subroutine Input
 
     Subroutine Init
+        Use utils, Only : DetermineRecordLength
         Implicit None
         Integer  :: ic, n, j, imax, ni, kkj, llj, nnj, i, nj, If, &
                     ii, i1, n2, n1, l, nmin, jlj, i0, nlmax, err_stat
@@ -108,7 +118,7 @@ Contains
         Integer, Dimension(33)  ::  nnn ,jjj ,nqq 
         Character(Len=1), Dimension(9) :: Let 
         Character(Len=1), Dimension(33):: lll
-        logical :: longbasis
+        logical :: longbasis, success
         Integer, Dimension(4*IPs) :: IQN
         Real(dp), Dimension(IPs)  :: Qq1
         Character(Len=256) :: strfmt, err_msg
@@ -119,8 +129,14 @@ Contains
 
         c1 = 0.01d0
         mj = 2*abs(Jm)+0.01d0
+        
+        Call DetermineRecordLength(Mrec, success)
+        If (.not. success) Then
+            Write(*,*) 'ERROR: record length could not be determined'
+            Stop
+        End If
 
-        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             strfmt='(/2X,"file CONF.DAT is absent"/)'
             Write( *,strfmt)
@@ -456,7 +472,7 @@ Contains
         Else
             count = Ngint*2_int64
         End If
-        Call BroadcastD(Rint2, count, 0, 0, MPI_COMM_WORLD, mpierr)
+        Call BroadcastD(Rint2, count, 0, mpi_type2_real, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(Iint1(1:Nhint), Nhint, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint2, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint3, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
@@ -612,14 +628,14 @@ Contains
 
                     If (nnc == nccnt .and. nnc /= ncsplit*10) Then
                         Call stopTimer(s1, timeStr)
-                        If (moreTimers == .true.) Write(*,'(2X,A,1X,I3,A)'), 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
+                        If (moreTimers) Write(*,'(2X,A,1X,I3,A)') 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
                         j=j-1
                         nccnt = nccnt + ncsplit
                     End If
 
                     If (num_done == npes-1) Then
                         Call stopTimer(s1, timeStr)
-                        If (moreTimers == .true.) Write(*,'(2X,A,1X,I3,A)'), 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
+                        If (moreTimers) Write(*,'(2X,A,1X,I3,A)') 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
                         Exit
                     End If
                 End Do

--- a/src/conf_pt.f90
+++ b/src/conf_pt.f90
@@ -25,6 +25,8 @@ Program conf_pt
     integer, allocatable, dimension(:)    :: Ndcnr, Nvcnr, NRR, NRN, Ndirc
     real(dp), allocatable, dimension(:)   :: B1h, En, Xj, EnG, Ey, DEnr, DVnr
     real(dp), allocatable, dimension(:,:) :: X0
+    
+    Type(MPI_Datatype) :: mpi_type2_real
 
     !     - - - - - - - - - - - - - - - - - - - - - - - - -
     !
@@ -162,6 +164,7 @@ Contains
     End Subroutine Input
 
     Subroutine Init
+        Use utils, Only : DetermineRecordLength
         Implicit None
         Integer                     :: ii, ni, If, nj, i, nnj, llj, jlj, kkj, err_stat, &
                                        nec, imax, j, n, ic, i0, nmin, i1, n2, n1, l
@@ -173,7 +176,8 @@ Contains
         Integer, Dimension(33)      :: nnn, jjj, nqq
         Character(Len=1)            :: Let(9), lll(33)
         Character(Len=512)          :: strfmt, err_msg
-        Logical                     :: longbasis
+        Logical                     :: longbasis, success
+
         equivalence (IQN(1),PQ(21)),(Qq1(1),PQ(2*IPs+21))
         equivalence (p(1),pq(1)), (q(1),pq(IP6+1)), &
                     (p1(1),pq(2*IP6+1)), (q1(1),pq(3*IP6+1))
@@ -182,7 +186,13 @@ Contains
         c1 = 0.01d0
         mj = 2*abs(Jm)+0.01d0
 
-        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        Call DetermineRecordLength(Mrec, success)
+        If (.not. success) Then
+            Write(*,*) 'ERROR: record length could not be determined'
+            Stop
+        End If
+
+        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             strfmt='(/2X,"file CONF.DAT is absent"/)'
             Write( *,strfmt)
@@ -471,7 +481,7 @@ Contains
         Call BroadcastI(Iint2, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint3, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(IntOrd, nrd, MPI_INTEGER8, 0, MPI_COMM_WORLD, mpierr)
-        Call BroadcastD(Rint2, count, 0, 0, MPI_COMM_WORLD, mpierr)
+        Call BroadcastD(Rint2, count, 0, mpi_type2_real, 0, MPI_COMM_WORLD, mpierr)
         count = Ne*Int(Nd,kind=int64)
         Call BroadcastI(Iarr, count, 0, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(In, Ngaunt, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)

--- a/src/conf_pt.f90
+++ b/src/conf_pt.f90
@@ -117,13 +117,13 @@ Contains
         ! Write name of program
         Select Case(type2_real)
         Case(sp)
-            strfmt = '(/4X,"Program CONF_PT v2.2", &
+            strfmt = '(/4X,"Program CONF_PT v2.3", &
                /4X,"PT corrections to binding energy", & 
                /4X,"Zero approximation is taken from CONF.XIJ", &
                /4X,"New vectors are in CONF_PT.XIJ and", &
                /4X,"new input is in CONF_new.INP")'
         Case(dp) 
-            strfmt = '(/4X,"Program CONF_PT v2.2 with double precision for 2e integrals", &
+            strfmt = '(/4X,"Program CONF_PT v2.3 with double precision for 2e integrals", &
                /4X,"PT corrections to binding energy", & 
                /4X,"Zero approximation is taken from CONF.XIJ", &
                /4X,"New vectors are in CONF_PT.XIJ and", &

--- a/src/conf_variables.f90
+++ b/src/conf_variables.f90
@@ -40,7 +40,7 @@ Module conf_variables
     Real(dp), Dimension(IPs)   :: Eps
     Real(dp), Dimension(IP1)   :: C
 
-    Type Matrix(knd)
+    Type :: Matrix(knd)
         Integer, kind :: knd
         Real(kind=knd) :: minval
         Integer,  Allocatable, Dimension(:) :: ind1, ind2

--- a/src/davidson.f90
+++ b/src/davidson.f90
@@ -11,7 +11,7 @@ Module davidson
 
   Contains
     
-    Subroutine Init4(mype)
+    Subroutine Init4(mype, mpi_type_real)
         ! This subroutine constructs the initial approximation 
         ! by selecting configurations specified by parameter Nc4.
         ! The initial approximation Hamilonian is stored in the 
@@ -22,6 +22,8 @@ Module davidson
         Use determinants, Only : calcNd0
         Use str_fmt, Only : FormattedTime, startTimer, stopTimer
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer  :: k, n, mype, mpierr
         Integer(Kind=int64) :: l8, s1
         Real(type_real) :: t
@@ -64,12 +66,12 @@ Module davidson
 
         If (mype == 0) Then
             Call stopTimer(s1, timeStr)
-            Write(*,'(2X,A)'), 'TIMING >>> Initial approximation constructed in '// trim(timeStr)
+            Write(*,'(2X,A)') 'TIMING >>> Initial approximation constructed in '// trim(timeStr)
         End If
 
     End Subroutine Init4
 
-    Subroutine FormB0(mype)
+    Subroutine FormB0(mype, mpi_type_real)
         ! This subroutine constructs the initial eigenvectors for the Davidson iteration
         ! and stores them in the first block of ArrB.
         ! Eigenvectors are written to CONF.XIJ 
@@ -77,6 +79,8 @@ Module davidson
         Use formj2, Only : J_av
         Use str_fmt, Only : FormattedTime, startTimer, stopTimer
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer :: i, j, idum, ndpt, ierr, num, nskip, mpierr, mype
         Integer(kind=int64) :: s1
         Real(dp) :: dummy
@@ -98,7 +102,7 @@ Module davidson
         If (abs(Kl4) /= 2) Then ! If not reading CONF.XIJ
             Do j=1,Nd0
                 B1(1:Nd0)=Z1(1:Nd0,j)
-                Call J_av(B1,Nd0,xj,ierr)
+                Call J_av(B1,Nd0,xj,mpi_type_real,ierr)
                 If (ierr == 0) Then
                     num=num+1
                     E(num)=-(E1(j)+Hamil%minval)
@@ -140,7 +144,7 @@ Module davidson
                 Write(11,*) ' Selection is done', nskip,' vectors skiped'
             End If
             Call stopTimer(s1, timeStr)
-            Write(*,'(2X,A)'), 'TIMING >>> Initial eigenvectors constructed in '// trim(timeStr) // '.'
+            Write(*,'(2X,A)') 'TIMING >>> Initial eigenvectors constructed in '// trim(timeStr) // '.'
         End If
         
         Return
@@ -377,13 +381,15 @@ Module davidson
         Return
     End Subroutine Dvdsn
 
-    Subroutine Mxmpy(ip, mype)
+    Subroutine Mxmpy(ip, mpi_type_real, mype)
         ! This subroutine evaluates the products Q_i = H_ij * B_j
         ! if ip=1, products are stored in the second block of ArrB
         ! if ip=2, products are stored in the third block of ArrB
         Use mpi_f08
         Use mpi_utils, Only : BroadcastD
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer, Intent(In) :: ip, mype
 
         Integer :: i, k, nlp, n, mpierr, i2min, i2max, i1min, i1max, kd
@@ -420,7 +426,6 @@ Module davidson
                 t=t-Hamil%minval
                 If (kd == 1) Diag(n)=t
             End If
-            !If (devmode == 1 .and. mype == 1) print*, n, k, t, ArrB(n,i2min:i2max)
             ArrB(n,i2min:i2max)=ArrB(n,i2min:i2max)+t*ArrB(k,i1min:i1max)
             If (n /= k) ArrB(k,i2min:i2max)=ArrB(k,i2min:i2max)+t*ArrB(n,i1min:i1max)
         End Do
@@ -505,12 +510,15 @@ Module davidson
         Return
     End Subroutine Ortn
 
-    Subroutine Prj_J(lin, num, lout, trsd, mype) 
+    Subroutine Prj_J(lin, num, lout, trsd, mpi_type_real, mype) 
         Use mpi_f08
         Use determinants, Only : Gdet
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer :: ierr, i, n, k, j, i2, i1, jx, it, iter, lout, num, lin, jav, mpierr, imin, imax
         Integer, optional :: mype
+        Integer(kind=int64) :: j8
         Real(dp) :: err1, err, f, trsd
         Real(type_real) :: t, sj, aj, s, s1, a
         logical :: proceed
@@ -523,7 +531,7 @@ Module davidson
             Write(11,strfmt) Nlv,lout+num-1,IPlv
             Stop
         End If
-        jav=2*XJ_av+0.1d0
+        jav=Int(2*XJ_av+0.1d0)
         If (mype == 0) Then
             strfmt = '(4X,"Prj_J: projecting",I3," vectors on subspace J=",F5.1)'
             Write( *,strfmt) num,XJ_av
@@ -548,10 +556,10 @@ Module davidson
                     i2=lout+i-1
                     ArrB(1:Nd,i2)=0_type_real
                 End Do
-                Do j=1,ij8
-                    n=Jsq%ind1(j)
-                    k=Jsq%ind2(j)
-                    t=Jsq%val(j)
+                Do j8=1,ij8
+                    n=Jsq%ind1(j8)
+                    k=Jsq%ind2(j8)
+                    t=Jsq%val(j8)
                     Do i=1,num
                         proceed=(lin-1)*Iconverge(i)==0
                         If (proceed) Then

--- a/src/determinants.f90
+++ b/src/determinants.f90
@@ -96,7 +96,7 @@ Module determinants
     Subroutine Jterm
         Implicit None
 
-        Integer         :: i, j, mt, n, im, ndi, nd1, imax, iconf, ndi1, iconf1, jmax
+        Integer         :: j, mt, n, im, ndi, nd1, imax, iconf, ndi1, iconf1, jmax
         Real(dp)        :: d
         Integer, allocatable, dimension(:) :: idet, nmj
         logical :: fin, swapped
@@ -492,7 +492,7 @@ Module determinants
         ! it does NOT post-process the located indices to determine scaling factor (is) or
         ! correct differing indices
         !
-        ! The two Integer index vectors, "i" and "j", are three elements in size and are
+        ! The two integer index vectors, "i" and "j", are three elements in size and are
         ! used as:
         !
         !     i(1)        running index over comparison

--- a/src/diff.f90
+++ b/src/diff.f90
@@ -111,7 +111,7 @@ Module diff
         If (dabs(err).GT.1.d-1) Then
             Write(*,'(4X,"Dif: matching error at R1. Taylor:",E12.5, &
                    ", Num:",E12.5,/4X,"Using Origin for new expansion.")') cp1,CP(1)
-            Ierr=Ierr+10*dabs(err)
+            ierr=ierr+10*Int(dabs(err))
             If (dabs(CP(ii+5)).GT.dabs(CP(ii+6))) Then
                 kap=1                            ! For kap>0 expansion
             Else                                 ! goes over even powers
@@ -176,6 +176,7 @@ Module diff
         If (MaxT.EQ.0) MaxT=9        !### hfd uses Nmax instead of MaxT
 
         P(ii+5:ii+5+MaxT)=0.d0
+        ierr=0
 
         If (P(1).EQ.0.d0) Return
 
@@ -226,7 +227,7 @@ Module diff
         pr2=rk*(c0+c1*y+c2*y*y+c3*y**3)*R(2)**gam / P(2) !# should be equal to 1
         dr2=rk*(g*c0+(g+2)*c1*y+(g+4)*c2*y*y+(g+6)*c3*y**3)*R(2)**(gam-1) / dp2    
 
-        ier=1.d6*(dabs(pr1-1.d0)+dabs(dr1-1.d0)+dabs(pr2-1.d0)+dabs(dr2-1.d0))
+        ier=Int(1.d6*(dabs(pr1-1.d0)+dabs(dr1-1.d0)+dabs(pr2-1.d0)+dabs(dr2-1.d0)))
         If (ier.GE.1) Then
             strfmt='(4X,"Expansion error for gam = ",F5.1," kap = ",I2, &
                 /4X,"pr1 = ",E15.7," dr1 = ",E15.7 &

--- a/src/diff.f90
+++ b/src/diff.f90
@@ -14,9 +14,9 @@ Module diff
         ! This subroutine should be used for functions which are not very smooth at R=R(1).
         Implicit None
 
-        Integer :: i, ii, ih, im, ix, j, i1, ih2, ih3, ih4, ih5, ih6, ierr, kap, kt, MaxT
+        Integer :: i, ii, ih, im, ix, j, i1, ih2, ih3, ih4, ih5, ih6, ierr, kap, kt, MaxT, m
         Real(dp) :: h60, gm, r1, cp1, p1, pim, scale, err, h
-        Real(dp), Dimension(IP6) :: P, CP, R, V                 !
+        Real(dp), Dimension(IP6) :: P, CP, R, V
 
         If (MaxT.EQ.0) MaxT=9      !### hfd uses Nmax instead of MaxT
         ih=2-kt

--- a/src/env_var.f90
+++ b/src/env_var.f90
@@ -34,9 +34,11 @@ Module env_var
         GetEnvLogical = defaultValue
         Call GetEnv(varName, varValue)
         If (Len_Trim(varValue) > 0) then
-            If (varValue == 'y' .or. varValue == 'Y' .or. varValue == 'yes' .or. varValue == 'YES' .or. varValue == 't' .or. varValue == 'T' .or. varValue == 'true' .or. varValue == 'TRUE') then
+            If (varValue == 'y' .or. varValue == 'Y' .or. varValue == 'yes' .or. varValue == 'YES' &
+                .or. varValue == 't' .or. varValue == 'T' .or. varValue == 'true' .or. varValue == 'TRUE') then
                 GetEnvLogical = .true.
-            Else If (varValue == 'n' .or. varValue == 'N' .or. varValue == 'no' .or. varValue == 'NO' .or. varValue == 'f' .or. varValue == 'F' .or. varValue == 'false' .or. varValue == 'FALSE') then
+            Else If (varValue == 'n' .or. varValue == 'N' .or. varValue == 'no' .or. varValue == 'NO' .or. &
+                    varValue == 'f' .or. varValue == 'F' .or. varValue == 'false' .or. varValue == 'FALSE') then
                 GetEnvLogical = .false.
             Else
                 Read(varValue,*,iostat=convStat) iValue

--- a/src/formy.f90
+++ b/src/formy.f90
@@ -1,5 +1,5 @@
 program formy
-    use params, ipmr1 => IPmr, IP1conf => IP1
+    use params, IP1conf => IP1
     use determinants, only : Dinit, Jterm
     use str_fmt, only : startTimer, stopTimer, FormattedTime
     use mpi_f08
@@ -44,9 +44,8 @@ program formy
     call BcastVector(mype)
     call Vector(kl,mype)                   !###  the equation and vectors Yi
 
-    
     call stopTimer(start_time, timeStr)
-    If (mype == 0) write(*,'(2X,A)'), 'TIMING >>> Total computation time of ine was '// trim(timeStr)
+    If (mype == 0) write(*,'(2X,A)') 'TIMING >>> Total computation time of formy was '// trim(timeStr)
 
     call MPI_Finalize(mpierr)
 

--- a/src/formy.f90
+++ b/src/formy.f90
@@ -489,7 +489,7 @@ contains
           Write(*,'(A,1pD8.1)')' W00=',W00
         End If
 
-        strfmt = '(1X,70("#"),/1X,"Program FormY v1.0",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
+        strfmt = '(1X,70("#"),/1X,"Program FormY v1.1",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
         Write( 6,strfmt) str(kli),str(klf)
         Write(11,strfmt) str(kli),str(klf)
 

--- a/src/hfd.f90
+++ b/src/hfd.f90
@@ -454,7 +454,7 @@ Contains
         strfmt = '(1X,16A1)'
         Read(10,strfmt) NAME
 
-        strfmt = '(/2X,"PROGRAM HFD (version with IS and Breit) v1.2",4X,16A1)'
+        strfmt = '(/2X,"PROGRAM HFD (version with IS and Breit) v1.3",4X,16A1)'
         Write( *,strfmt) NAME
         Write(11,strfmt) NAME
 

--- a/src/hfd.f90
+++ b/src/hfd.f90
@@ -1,9 +1,10 @@
 Program hfd
     Use params, Ncc => Nc, Nqparams => Nq, Nnparams => Nn, Llparams => Ll, Kkparams => Kk, Jjparams => Jj
+    Use utils, Only : DetermineRecordLength
 
     Implicit None
 
-    Integer :: Mrec, iconf, MaxNc, is, ni, kt, ki, kf, n12, l, i, ii, nii, nit, iwr, iis, MaxT, &
+    Integer :: iconf, MaxNc, is, ni, kt, ki, kf, n12, l, i, ii, nii, nit, iwr, iis, MaxT, &
                 m1, m2, m3, ifin, kbr, n_is, Nmax, Imax, Nsmin, Nsmax, Ni0, Niter, ng, Lag, Klag
     Real(dp) :: eps0, eps1, e, d, del, r2, Rnucl, Gs, Es, Al, Bt, Cl, G0, R1, xja, xjc, Hs, Bts, Als
     Real(dp), Dimension(10) :: Vnuc
@@ -16,6 +17,7 @@ Program hfd
     Real(dp), Allocatable, Dimension(:) :: Qq, Qw, Zat
     Character(Len=1) :: let(5), str(4)*8, str1(2)*5, name(16)
     Character(Len=256) :: strfmt
+    Logical :: success
     
     let(1)='S'
     let(2)='P'
@@ -65,8 +67,11 @@ Program hfd
     M3=0
     
     Call OpenFS('HFD.RES',11,1)
-    Call recunit  ! determines word length
-    Mrec=ipmr
+    Call DetermineRecordLength(Mrec, success)
+    If (.not. success) Then
+        Write(*,*) 'ERROR: record length could not be determined'
+        Stop
+    End If
     Call INPUT
 
     eps0=1.d-7         !### eps0 defines covergence criterion
@@ -180,41 +185,6 @@ Program hfd
     Call CLOSEF(12)
 
 Contains
-
-    Subroutine recunit
-        ! Determination of the record unit.
-        Implicit None
-        
-        Integer :: lrec, iflag, ipmr, nbytes
-        Character(Len=8) :: d1,t1,d2,t2
-
-        t1='abcdefgh'
-        d1='        '
-        t2='hgfedcba'
-        d2='        '
-        lrec=0
-        iflag=1
-200     lrec=lrec+1
-        if (lrec.gt.8) then
-          write(*,*)  'lrec > 8'
-          stop
-        end if
-        open(unit=13,file='test.tmp',status='unknown',access='direct',recl=lrec)
-        write(13,rec=1,err=210) t1
-        write(13,rec=2,err=210) t2
-        read(13,rec=1,err=210) d1
-        read(13,rec=2,err=210) d2
-        if (d1.ne.t1) goto 210
-        if (d2.ne.t2) goto 210
-        iflag=0
-210     close(unit=13,status='delete')
-        if (iflag.ne.0) goto 200
-        nbytes=8/lrec
-        ipmr=4/nbytes
-
-        Return
-
-    End Subroutine recunit
 
     Subroutine OpenFS(fnam,kan,ntype)
         Implicit None
@@ -1240,8 +1210,11 @@ Contains
     Subroutine Fed(ni)
         Implicit None
 
-        Integer :: ni, ih, k, n, mm, im, j, i0, i1, i2, j1, j2, j3, j4, n1, n3, nt1, nt3, nj, i, m, l
-        Real(dp) :: eps, h1, hh, gam, e, e0, st, t, t1, s, hk, t2, t3, tp, tq, qm2, rj, pi, qi, pj, qj, d, dw, dc, da, db, dt, dq, pm2, e1, e3, dt1, dt3, dpp
+        Integer :: ni, ih, k, n, mm, im, j, i0, i1, i2, j1, j2, j3, j4, &
+                    n1, n3, nt1, nt3, nj, i, m, l
+        Real(dp) :: eps, h1, hh, gam, e, e0, st, t, t1, s, hk, &
+                    t2, t3, tp, tq, qm2, rj, pi, qi, pj, qj, &
+                    d, dw, dc, da, db, dt, dq, pm2, e1, e3, dt1, dt3, dpp
         Real(dp), Dimension(IP6) :: W
 
         W=0_dp
@@ -2968,13 +2941,13 @@ Contains
         Character(Len=256) :: strfmt
 
         C1=0.01D0
+
+        Allocate(Nn1(Ns), Kk1(Ns), Kp1(Ns), Nc1(Ns), Qq1(Ns))
         Nn1=0
         Kk1=0
         Kp1=0
         Nc1=0
         Qq1=0_dp
-
-        Allocate(Nn1(Ns), Kk1(Ns), Kp1(Ns), Nc1(Ns), Qq1(Ns))
 
         ITEST=0
         CALL READF (12,1,P,P,1)
@@ -3079,7 +3052,8 @@ Contains
             end if
 
             IF (ITEST.EQ.2) GOTO 380
-            strfmt = '(/2X,"CONFIGURATION WAS CHANGED"//10X,"HFD.INP",26X,"HFD.DAT"//8X,"NL",2X,"JJ",4X,"QQ",2X,"NC",16X,"NL",2X,"JJ",4X,"QQ",2X,"NC")'
+            strfmt = '(/2X,"CONFIGURATION WAS CHANGED"//10X,"HFD.INP",26X,"HFD.DAT"//8X,&
+                        "NL",2X,"JJ",4X,"QQ",2X,"NC",16X,"NL",2X,"JJ",4X,"QQ",2X,"NC")'
             WRITE( *,strfmt)
             WRITE(11,strfmt)
 

--- a/src/ine.f90
+++ b/src/ine.f90
@@ -365,7 +365,7 @@ Contains
           Write(*,'(A,1pD8.1)')' W00=',W00
         End If
 
-        strfmt = '(1X,70("#"),/1X,"Program InhomEq. v1.23",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
+        strfmt = '(1X,70("#"),/1X,"Program InhomEq. v1.24",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
         Write( 6,strfmt) str(kli),str(klf)
         Write(11,strfmt) str(kli),str(klf)
 

--- a/src/ine.f90
+++ b/src/ine.f90
@@ -51,7 +51,7 @@ Program ine
     !         General convention: GLOBAL VARIABLES     |||
     !              ARE CAPITALISED                     |||
     ! ||||||||||||||||||||||||||||||||||||||||||||||||||||
-    Use params, ipmr1 => IPmr, IP1conf => IP1
+    Use params, IP1conf => IP1
     Use determinants, Only : Dinit, Jterm
     Use str_fmt, Only : startTimer, stopTimer
 
@@ -202,7 +202,7 @@ Program ine
     Close(unit=11) ! Close INE.RES
     Close(unit=99) ! Close INEFINAL.RES
     Call stopTimer(start_time, timeStr)
-    Write(*,'(2X,A)'), 'TIMING >>> Total computation time of ine was '// trim(timeStr)
+    Write(*,'(2X,A)') 'TIMING >>> Total computation time of ine was '// trim(timeStr)
     
 Contains
 
@@ -946,7 +946,7 @@ Contains
         If (.not. Allocated(Hamil%t)) Allocate(Hamil%t(NumH))
         cnt=0
         Do i8=1,NumH
-            Read(15), Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
+            Read(15) Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
             if (Hamil%n(i8) == Nd + 1) then
                 NumH=cnt
                 print*,'For Nd=',Nd,', NumH=', NumH
@@ -1090,7 +1090,7 @@ Contains
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
         
         strfmt = '(3X," NumH =",I12,";  Hmin =",F12.6/)'
         Write(*,strfmt) NumH,Hmin
@@ -1124,14 +1124,14 @@ Contains
         Call system_clock(end2)
         ttime2=Real((end2-start2)/clock_rate)
         Call FormattedTime(ttime2, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Zspsv in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Zspsv in '// trim(timeStr)// '.'
 
         X1= 0.d0 
         X1(1:Ntr)= Real(XX1(1:Ntr), kind=dp)
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: decomp in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: decomp in '// trim(timeStr)// '.'
 
         ! Orthogonalization of X1 to X0 (If J0 /= 0)
         If (Kli.EQ.5 .AND. dabs(Tj0).GT.0.51d0) Call Ort  

--- a/src/integrals.f90
+++ b/src/integrals.f90
@@ -13,7 +13,7 @@ Module integrals
     subroutine Rint
         Implicit None
         Integer     :: i, nsh, ns1, nso1, nsu1, nsp1, Nlist, &
-                       k, mlow, m_is, err_stat, kbrt1, nx1
+                       k, mlow, m_is, err_stat, kbrt1
         Integer(Kind=int64) :: i8
         Character*7 :: str(3),str1(4)*4
         Character(Len=3) :: key1, key2
@@ -162,18 +162,20 @@ Module integrals
     Real(dp) Function Gint(i1,i2,i3,i4)
         Implicit None
         Integer  :: i2, ib, i1, ia, is, la, nd, nc, nb, na, md, mc, mb, ma, &
-                    is_sms, ii, i4, id, i3, ic, iac, k1, is_br, i_br, minint, &
+                    is_sms, ii, i4, id, i3, ic, iac, k1, is_br, i_br, &
                     iab, kmax, kmin, ibd0, iac0, k, jd, jc, jb, ja, ibr, i, ld, &
-                    lc, lb, ibd, kac, kbd, mi
-        Integer(Kind=int64) :: i8, mi8, minint8=0_int64
+                    lc, lb, ibd, kac, kbd
+        Integer(Kind=int64) :: i8, mi8, minint8
         Real(dp) :: e, rabcd
         Logical  :: l_is, l_br, l_pr
         Character(Len=256) :: strfmt
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         l_is= .not. (C_is == 0.d0)                ! False If C_is=0
         l_is=l_is .and. (K_is == 2 .or. K_is == 4)  ! False If K_is /= 2,4
         l_is=l_is .and. (K_sms >= 2)              ! False If K_sms<2
         l_br=Kbrt /= 0
+
+        minint8=0_int64
         e=0.d0
         is=1
         ia=i1
@@ -616,7 +618,7 @@ Module integrals
         m2=xm2
         is = 1
         g = 0.d0
-        im = abs(m2-m1)
+        im = Int(abs(m2-m1))
         If (k >= im) Then
             If (k == 0) Then
                 If (j1 == j2) Then
@@ -637,12 +639,12 @@ Module integrals
                 If (m1 <= 0.d0) Then
                    m1 = -m1
                    m2 = -m2
-                   ij = k+j1-j2
+                   ij = Int(k+j1-j2)
                    If(ij /= 2*(ij/2)) is = -is
                 End If
                 ib1=2*Nlx+1
                 ib2=ib1*ib1
-                ind = ib2*(ib2*k+2*(ib1*j1+j2))+ib1*(j1+m1)+(j2+m2)
+                ind = Int(ib2*(ib2*k+2*(ib1*j1+j2))+ib1*(j1+m1)+(j2+m2))
                 ! TODO - use num_gaunts_per_partial_wave to start looking for gaunt factors in their respective blocks of l
                 Do i=1,Ngaunt
                    If(In(i) == ind) Then

--- a/src/matrix_io.f90
+++ b/src/matrix_io.f90
@@ -149,7 +149,7 @@ Module matrix_io
         ! Print time to write file
         If (mype == 0) Then
             Call stopTimer(start_time, timeStr)
-            write(*,'(2X,A)'), 'TIMING >>> Writing ' // filename // ' took ' // trim(timeStr)
+            write(*,'(2X,A)') 'TIMING >>> Writing ' // filename // ' took ' // trim(timeStr)
         End If
     End Subroutine WriteMatrix
 
@@ -258,7 +258,7 @@ Module matrix_io
         ! Print time to write file
         If (mype == 0) Then
             Call stopTimer(start_time, timeStr)
-            write(*,'(2X,A)'), 'TIMING >>> Reading ' // filename // ' took ' // trim(timeStr)
+            write(*,'(2X,A)') 'TIMING >>> Reading ' // filename // ' took ' // trim(timeStr)
         End If
     
         Return

--- a/src/matrix_io.f90
+++ b/src/matrix_io.f90
@@ -14,7 +14,7 @@ Module matrix_io
   Contains
 
     Subroutine MPIErrHandle(mpierr)
-        Use mpi
+        Use mpi_f08
         Implicit None
         Integer, Intent(In) :: mpierr
 
@@ -64,13 +64,14 @@ Module matrix_io
         ! | mat%t (core 0) | mat%t (core 1) | ... | mat%t (core npes) |
         ! =============================================================
         !
-        Use mpi
+        Use mpi_f08
         Implicit None
         Type(Matrix(type_real)) :: mat
         Integer, Intent(In)             :: num_elements_per_core
         Integer(Kind=int64), Intent(In) :: num_elements_total
 
-        Integer                       :: mype, npes, i, mpierr, fh
+        Integer                       :: mype, npes, i, mpierr
+        Type(MPI_File)                :: fh
         Integer(Kind=Int64)           :: start_time
         Integer, Dimension(npes)      :: sizes
         Integer(kind=MPI_OFFSET_KIND), Dimension(npes) :: disps
@@ -95,47 +96,37 @@ Module matrix_io
         Call MPI_AllGather(num_elements_per_core, 1, MPI_INTEGER, sizes, 1, MPI_INTEGER, MPI_COMM_WORLD, mpierr)
         disps=0_MPI_OFFSET_KIND
         Do i=2,npes
-            disps(i)=disps(i-1)+sizes(i-1)
+            disps(i)=disps(i-1)+Int(sizes(i-1), kind=MPI_OFFSET_KIND)
         End Do
-    
+            
         ! Open file
         Call MPI_FILE_OPEN(MPI_COMM_WORLD, filename, MPI_MODE_WRONLY + MPI_MODE_CREATE, MPI_INFO_NULL, fh, mpierr) 
         Call MPIErrHandle(mpierr)
 
         ! Write number of matrix elements
         disp = mype * 4_MPI_OFFSET_KIND
-        Call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, MPI_INTEGER, 'native', MPI_INFO_NULL, mpierr) 
-        Call MPIErrHandle(mpierr)
-        Call MPI_FILE_WRITE(fh, num_elements_per_core, 1, MPI_INTEGER, MPI_STATUS_IGNORE, mpierr) 
+        Call MPI_FILE_WRITE_AT_ALL(fh, disp, num_elements_per_core, 1, MPI_INTEGER, MPI_STATUS_IGNORE, mpierr) 
         Call MPIErrHandle(mpierr)
 
         ! Write mat%ind1
         disp = (npes + disps(mype+1)) * 4_MPI_OFFSET_KIND
-        Call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, MPI_INTEGER, 'native', MPI_INFO_NULL, mpierr) 
-        Call MPIErrHandle(mpierr)
-        Call MPI_FILE_WRITE(fh, mat%ind1, num_elements_per_core, MPI_INTEGER, MPI_STATUS_IGNORE, mpierr) 
+        Call MPI_FILE_WRITE_AT(fh, disp, mat%ind1, num_elements_per_core, MPI_INTEGER, MPI_STATUS_IGNORE, mpierr) 
         Call MPIErrHandle(mpierr)
 
         ! Write mat%ind2
         disp = (npes + num_elements_total + disps(mype+1)) * 4_MPI_OFFSET_KIND
-        Call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, MPI_INTEGER, 'native', MPI_INFO_NULL, mpierr) 
-        Call MPIErrHandle(mpierr)
-        Call MPI_FILE_WRITE(fh, mat%ind2, num_elements_per_core, MPI_INTEGER, MPI_STATUS_IGNORE, mpierr) 
+        Call MPI_FILE_WRITE_AT(fh, disp, mat%ind2, num_elements_per_core, MPI_INTEGER, MPI_STATUS_IGNORE, mpierr) 
         Call MPIErrHandle(mpierr)
 
         ! Write mat%val
         Select Case(type_real)
         Case(sp)
             disp = (npes + 2 * num_elements_total) * 4_MPI_OFFSET_KIND + disps(mype+1) * 4_MPI_OFFSET_KIND
-            Call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, MPI_INTEGER, 'native', MPI_INFO_NULL, mpierr) 
-            Call MPIErrHandle(mpierr)
-            Call MPI_FILE_WRITE(fh, mat%val, num_elements_per_core, MPI_REAL, MPI_STATUS_IGNORE, mpierr) 
+            Call MPI_FILE_WRITE_AT(fh, disp, mat%val, num_elements_per_core, MPI_REAL, MPI_STATUS_IGNORE, mpierr) 
             Call MPIErrHandle(mpierr)
         Case(dp)
             disp = (npes + 2 * num_elements_total) * 4_MPI_OFFSET_KIND + disps(mype+1) * 8_MPI_OFFSET_KIND
-            Call MPI_FILE_SET_VIEW(fh, disp, MPI_INTEGER, MPI_INTEGER, 'native', MPI_INFO_NULL, mpierr) 
-            Call MPIErrHandle(mpierr)
-            Call MPI_FILE_WRITE(fh, mat%val, num_elements_per_core, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, mpierr) 
+            Call MPI_FILE_WRITE_AT(fh, disp, mat%val, num_elements_per_core, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, mpierr) 
             Call MPIErrHandle(mpierr)
         Case default 
             print*,'unrecognized real kind'
@@ -157,14 +148,15 @@ Module matrix_io
         !
         ! This subroutine reads a parallel matrix file 
         !
-        Use mpi
+        Use mpi_f08
         Implicit None
         Integer, Allocatable, Dimension(:)  :: indices1, indices2
         Real(kind=type_real), Allocatable, Dimension(:) :: values
         Integer, Intent(Out)             :: num_elements_per_core
         Integer(Kind=int64), Intent(Out) :: num_elements_total
 
-        Integer                                         :: mype, npes, npes_read, i, mpierr, fh
+        Integer                                         :: mype, npes, npes_read, i, mpierr
+        Type(MPI_File)                                  :: fh
         Integer(kind=int64)                             :: start_time
         Integer, dimension(npes)                        :: sizes
         Integer(kind=MPI_OFFSET_KIND), Dimension(npes)  :: disps

--- a/src/mpi_utils.f90
+++ b/src/mpi_utils.f90
@@ -29,7 +29,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                  :: comm
         Integer(Kind=int64), Intent(In)             :: count
         Integer, Intent(In)                         :: stride, rank
@@ -40,8 +39,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -73,7 +72,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                  :: comm
         Integer(Kind=int64), Intent(In)             :: count
         Integer, Intent(In)                         :: stride, rank
@@ -84,8 +82,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -114,11 +112,11 @@ Module mpi_utils
         End If
     End Subroutine BroadcastR
 
-    Subroutine BroadcastD(buffer, count, stride, rank, comm, mpierr)
+    Subroutine BroadcastD(buffer, count, stride, mpi_rtype, rank, comm, mpierr)
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
+        Type(MPI_Datatype), Intent(In)              :: mpi_rtype
         Type(MPI_Comm), Intent(In)                  :: comm
         Integer(Kind=int64), Intent(In)             :: count
         Integer, Intent(In)                         :: stride, rank
@@ -129,8 +127,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) Then
                 use_stride = MaxStride8Byte
                 If (type2_real == sp) use_stride = use_stride * 2
@@ -148,7 +146,7 @@ Module mpi_utils
         i = 1_int64
         mpierr = 0
         Do While (count_remain .gt. use_stride)
-            Call MPI_Bcast(buffer(i:i+use_stride), use_stride, mpi_type2_real, rank, comm, mpierr)
+            Call MPI_Bcast(buffer(i:i+use_stride), use_stride, mpi_rtype, rank, comm, mpierr)
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure broadcasting real range ',i,':',i+use_stride
                 Return
@@ -158,7 +156,7 @@ Module mpi_utils
         End Do
         If (count_remain .gt. 0) Then
             count_remain2 = count_remain
-            Call MPI_Bcast(buffer(i:i+count_remain2), count_remain2, mpi_type2_real, rank, comm, mpierr)
+            Call MPI_Bcast(buffer(i:i+count_remain2), count_remain2, mpi_rtype, rank, comm, mpierr)
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure broadcasting real range ',i,':',i+use_stride
                 Return
@@ -170,7 +168,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                  :: comm
         Type(MPI_Op), Intent(In)                    :: op
         Integer(Kind=int64), Intent(In)             :: count
@@ -182,8 +179,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -211,11 +208,11 @@ Module mpi_utils
         End If
     End Subroutine AllReduceI
 
-    Subroutine AllReduceR(buffer, count, stride, op, comm, mpierr)
+    Subroutine AllReduceR(buffer, count, stride, mpi_rtype, op, comm, mpierr)
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
+        Type(MPI_Datatype), Intent(In)                 :: mpi_rtype
         Type(MPI_Comm), Intent(In)                     :: comm
         Type(MPI_Op), Intent(In)                       :: op
         Integer(Kind=int64), Intent(In)                :: count
@@ -227,8 +224,8 @@ Module mpi_utils
         Integer                                        :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -238,7 +235,7 @@ Module mpi_utils
         i = 1_int64
         mpierr = 0
         Do While (count_remain .gt. use_stride)
-            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+use_stride), use_stride, mpi_type2_real, op, comm, mpierr) 
+            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+use_stride), use_stride, mpi_rtype, op, comm, mpierr) 
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure reducing real range ',i,':',i+use_stride
                 Return
@@ -248,7 +245,7 @@ Module mpi_utils
         End Do
         If (count_remain .gt. 0) Then
             count_remain2 = count_remain
-            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+count_remain2), count_remain2, mpi_type2_real, op, comm, mpierr) 
+            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+count_remain2), count_remain2, mpi_rtype, op, comm, mpierr) 
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure reducing real range ',i,':',i+use_stride
                 Return
@@ -260,7 +257,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                     :: comm
         Type(MPI_Op), Intent(In)                       :: op
         Integer(Kind=int64), Intent(In)                :: count
@@ -272,8 +268,8 @@ Module mpi_utils
         Integer                                        :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride

--- a/src/params.f90
+++ b/src/params.f90
@@ -38,9 +38,6 @@ Module params
 
     ! Set type2_real to determine whether to use single precision (sp) or double precision (dp) for two-electron and IS integrals
     Integer, Parameter :: type2_real=sp
-
-    ! Set key to turn on extra outputs for developing
-    Integer, Parameter :: devmode=1
     
     ! Global variables 
     Integer :: Ns, Nsp, Nso, Nsu, Ne, Nec, Nc, Nc4, Nd, Nlv, Ndr, Njd, Nst, Ncpt, N_it, Ngaunt, M, Mj, Mrec

--- a/src/params.f90
+++ b/src/params.f90
@@ -4,8 +4,7 @@ Module params
     !                      parameters determining dimensions of arrays,
     !                      and global variables and arrays used in parallel programs
     !
-    Use, Intrinsic :: iso_fortran_env, Only : sp => real32, dp => real64, int64
-    Use mpi_f08, Only : MPI_Datatype
+    Use, Intrinsic :: iso_fortran_env, Only : sp => real32, dp => real64, int32, int64
 
     Implicit None
     
@@ -33,23 +32,18 @@ Module params
 
     ! defining parameters which determine dimensions of main arrays in hfd
     Integer, Parameter :: IP6   =    470         ! record length for DAT files
-    Integer, Parameter :: IPmr  =      1         ! word length in direct access files
-                                                 ! =4 if word=1B (Pentium)
-                                                 ! =1 if word=4B (Alpha-processor)   
 
     ! Set type_real to determine whether to use single precision (sp) or double precision (dp) for Hamiltonian
     Integer, Parameter :: type_real=dp
-    Type(MPI_Datatype) :: mpi_type_real
 
     ! Set type2_real to determine whether to use single precision (sp) or double precision (dp) for two-electron and IS integrals
     Integer, Parameter :: type2_real=sp
-    Type(MPI_Datatype) :: mpi_type2_real
 
     ! Set key to turn on extra outputs for developing
     Integer, Parameter :: devmode=1
     
     ! Global variables 
-    Integer :: Ns, Nsp, Nso, Nsu, Ne, Nec, Nc, Nc4, Nd, Nlv, Ndr, Njd, Nst, Ncpt, N_it, Ngaunt, M, Mj
+    Integer :: Ns, Nsp, Nso, Nsu, Ne, Nec, Nc, Nc4, Nd, Nlv, Ndr, Njd, Nst, Ncpt, N_it, Ngaunt, M, Mj, Mrec
     Integer :: Kl, Kl4, Klow, Kc, Kv, Kbrt, Kout, Kecp, K_is, Kautobas, Jdel, Nx
     Real(dp) :: Z, H, Gj, gnuc, Rnuc, Qnuc, Cut0, C_is, Am, Jm, Crt4
 

--- a/src/pbasc.f90
+++ b/src/pbasc.f90
@@ -71,9 +71,9 @@ Contains
         Open(unit=11,status='UNKNOWN',file='BASC.RES')
         Select Case(type2_real)
         Case(sp)
-            strfmt = '(4X,"PROGRAM pbasc v3.0")'
+            strfmt = '(4X,"PROGRAM pbasc v3.1")'
         Case(dp)            
-            strfmt = '(4X,"PROGRAM pbasc v3.0 with double precision for 2e integrals")'
+            strfmt = '(4X,"PROGRAM pbasc v3.1 with double precision for 2e integrals")'
         End Select
         Write( *,strfmt)
         Write(11,strfmt)

--- a/src/pbasc.f90
+++ b/src/pbasc.f90
@@ -11,6 +11,9 @@ Program pbasc
     Integer :: Norb, nsx, nsx2, lsx
     Integer(kind=int64) :: start_time
     Character(Len=16) :: timeStr
+    Logical :: success
+
+    Type(MPI_Datatype) :: mpi_type2_real
 
     ! Initialize MPI
     Call MPI_Init(mpierr)
@@ -30,12 +33,11 @@ Program pbasc
     Call startTimer(start_time)
 
     If (mype == 0) Then
-        Call recunit
         Call Input
         Call Init(Norb) ! Norb = number of orbitals to be formed by Fbas:
         If (Norb /= 0) then
-            write (*,*) ' Run "bass" to form ',Norb,' new orbitals.'
-            stop
+            Write (*,*) ' Run "bass" to form ',Norb,' new orbitals.'
+            Stop
         End If
         Call Fill_N_l
         Call Core
@@ -51,46 +53,12 @@ Program pbasc
         write(*,*)' GAUNT finished'
         Close(11)
         Call stopTimer(start_time, timeStr)
-        write(*,'(2X,A)'), 'TIMING >>> Total computation time of basc was '// trim(timeStr)
+        write(*,'(2X,A)') 'TIMING >>> Total computation time of basc was '// trim(timeStr)
     End If
 
     Call MPI_Finalize(mpierr)
 
 Contains
-
-    Subroutine recunit
-        ! This subroutine determines the record unit
-        Implicit None
-
-        Integer          :: lrec, iflag, nbytes
-        Character(Len=8) :: d1, t1, d2, t2
-
-        t1='abcdefgh'
-        d1='        '
-        t2='hgfedcba'
-        d2='        '
-        lrec=0
-        iflag=1
-200     lrec=lrec+1
-        If (lrec > 8) Then
-          Write(*,*)  'lrec > 8'
-          Stop
-        End If
-        Open(unit=13,file='test.tmp',status='unknown',access='direct',recl=lrec)
-        Write(13,rec=1,err=210) t1
-        Write(13,rec=2,err=210) t2
-        Read(13,rec=1,err=210) d1
-        Read(13,rec=2,err=210) d2
-        If (d1 /= t1) goto 210
-        If (d2 /= t2) goto 210
-        iflag=0
-210     Close(unit=13,status='delete')
-        If (iflag /= 0) goto 200
-        nbytes=8/lrec
-        ipmr=4/nbytes
-
-        Return
-    End Subroutine recunit
 
     Subroutine Input
         Use conf_init, Only : ReadConfInp, ReadConfigurations
@@ -135,10 +103,11 @@ Contains
 
     Subroutine Init(Norb)
         Use readfff
+        Use utils, Only : DetermineRecordLength
         Implicit None
         Integer, Intent(Out) :: Norb
 
-        Integer :: i, i0, ic, imax, j, n, n0, ni, nmin, nsmax, nsmax1, If
+        Integer :: i, i0, ic, imax, j, n, n0, ni, nmin, nsmax, nsmax1, nf
         Integer :: nsb, kkj, llj, jjj, nj, ng, nnj, err_stat
         Real(dp) :: c1, c2, r1, z1, d
         Integer, Dimension(4*IPs) :: IQN
@@ -159,7 +128,13 @@ Contains
         Mj=2*dabs(Jm)+0.01d0
         Qw=0_dp
 
-        Open(12,file='HFD.DAT',access='DIRECT',status='OLD',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        Call DetermineRecordLength(Mrec, success)
+        If (.not. success) Then
+            Write(*,*) 'ERROR: record length could not be determined'
+            Stop
+        End If
+
+        Open(12,file='HFD.DAT',access='DIRECT',status='OLD',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             strfmt='(/2X,"file HFD.DAT is absent"/)'
             Write( *,strfmt)
@@ -211,20 +186,20 @@ Contains
                 Qq(ni)=Qq1(ni)
             End Do
         Else
-            If=20
+            nf=20
             Do ni=1,Ns
-                If=If+1
-                Nn(ni)=PQ(If)+c1
-                If=If+1
-                Ll(ni)=PQ(If)+c1
-                If=If+1
-                Qq(ni)=PQ(If)
-                If=If+2
-                c2=dsign(c1,PQ(If))
-                Kk(ni)=PQ(If)+c2
-                If=If+1
-                c2=dsign(c1,PQ(If))
-                Jj(ni)=PQ(If)+c2
+                nf=nf+1
+                Nn(ni)=PQ(nf)+c1
+                nf=nf+1
+                Ll(ni)=PQ(nf)+c1
+                nf=nf+1
+                Qq(ni)=PQ(nf)
+                nf=nf+2
+                c2=dsign(c1,PQ(nf))
+                Kk(ni)=PQ(nf)+c2
+                nf=nf+1
+                c2=dsign(c1,PQ(nf))
+                Jj(ni)=PQ(nf)+c2
                 Qw(ni)=0.d0
             End Do
         End If
@@ -236,13 +211,13 @@ Contains
             i=dsign(1.d0,Qnl(nj))
             d=dabs(Qnl(nj))+1.d-14
             d=10.0*d
-            nnj=d
+            nnj=Int(d)
             d=10.0d0*(d-nnj)
-            llj=d
+            llj=Int(d)
             jjj=2*llj+i
             kkj=-i*((jjj+1)/2)
             d=100.0d0*(d-llj)
-            Nq(nj)=d+0.1d0
+            Nq(nj)=Int(d+0.1d0)
             If (nj <= Nso) Then
                 Do ni=1,Nso
                     If (Nn(ni) == Nn(nj) .and. Ll(ni) == Ll(nj)) Qw(ni) = Qw(ni) + Nq(nj)   ! number of e on NR shell
@@ -320,7 +295,7 @@ Contains
             n=0
             i=0
         End Do
-        Open(13,file='CONF.DAT',status='UNKNOWN',access='DIRECT',recl=2*IP6*IPmr)
+        Open(13,file='CONF.DAT',status='UNKNOWN',access='DIRECT',recl=2*IP6*Mrec)
         Do ni=1,4
             Call ReadF (12,ni,P,Q,2)
             Call WriteF(13,ni,P,Q,2)
@@ -388,7 +363,7 @@ Contains
         Real(dp), Dimension(20) :: dd, ss
         Character(Len=512) :: strfmt
 
-        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr)
+        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec)
         Ecore=0.d0
         Hcore=0.d0
         Ebcore=0.d0
@@ -894,7 +869,7 @@ Contains
         Integer :: lnx, num_is, nx, i, Idel, idel1, nsx, ih, nmin, na, lsx
         Integer :: nna, lla, jjd, lb, la, nnc, nnb, iis, nb, n4, n3, n2, n1
         Integer :: nsx2, kmin, kmax, k, k1, lc, ld, ja, jb, jc, jd, Iab, nm_br
-        Integer :: ln, kac, kbd, n0, nad, jja, nnd, lld, cut1, rem, ngint4
+        Integer :: ln, kac, kbd, n0, nad, jja, nnd, lld
         Integer(Kind=int64) :: ngint2, i8, count
         Real(dp) :: dint1, r_e1, r_e2, fis, tab_br, tad_br, r_br, rabcd, r_c, tad
         Real(dp), Dimension(IP6) :: cp, cq, ca, cb
@@ -951,7 +926,7 @@ Contains
             Continue
         Else
             If (mype == 0) Then
-                Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr)
+                Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec)
                 ih=2-Kt
                 nmin=Nso+1
 
@@ -1005,7 +980,7 @@ Contains
                 End Do
 
                 Call stopTimer(start_time, timeStr)
-                Write(*,'(2X,A)'), 'TIMING >>> Evaluation of one-electron integrals took '// trim(timeStr)
+                Write(*,'(2X,A)') 'TIMING >>> Evaluation of one-electron integrals took '// trim(timeStr)
             End If
             If (K_is == 1) num_is=nhint            
 
@@ -1160,7 +1135,7 @@ Contains
                 Else
                     count = ngint*2_int64
                 End If
-                Call AllReduceR(Rint2, count, 0, MPI_SUM, MPI_COMM_WORLD, mpierr)
+                Call AllReduceR(Rint2, count, 0, mpi_type2_real, MPI_SUM, MPI_COMM_WORLD, mpierr)
                 Call AllReduceI(Iint2, ngint, 0, MPI_SUM, MPI_COMM_WORLD, mpierr)
                 Call AllReduceI(Iint3, ngint, 0, MPI_SUM, MPI_COMM_WORLD, mpierr)
 
@@ -1177,7 +1152,7 @@ Contains
             If (Ne /= 1) Call PrintRint2Table(idel1)
 
             Call stopTimer(start_time, timeStr)
-            Write(*,'(2X,A)'), 'TIMING >>> Evaluation of two-electron integrals took '// trim(timeStr)
+            Write(*,'(2X,A)') 'TIMING >>> Evaluation of two-electron integrals took '// trim(timeStr)
 
             Close(unit=12)
 
@@ -1188,7 +1163,7 @@ Contains
  
             ! >>>>>>>>>>>>>> MS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
             If (K_is >= 2) Then
-                Open(13,file='HFD.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr)
+                Open(13,file='HFD.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec)
                 Call Rint_MS(nsx,lsx,num_is)
                 Close(13)
             End If

--- a/src/pconf.F90
+++ b/src/pconf.F90
@@ -188,13 +188,13 @@ Contains
 
         Select Case(type_real)
         Case(sp)
-            strfmt = '(4X,"Program pconf v6.1 with single precision")'
+            strfmt = '(4X,"Program pconf v6.2 with single precision")'
         Case(dp)            
             Select Case(type2_real)
             Case(sp)
-                strfmt = '(4X,"Program pconf v6.1")'
+                strfmt = '(4X,"Program pconf v6.2")'
             Case(dp)
-                strfmt = '(4X,"Program pconf v6.1 with double precision for 2e integrals")'
+                strfmt = '(4X,"Program pconf v6.2 with double precision for 2e integrals")'
             End Select
         End Select
         
@@ -1645,16 +1645,16 @@ Contains
                 Else
                     Write(*,"(A,I12,A,I12)") "DiagInitApprox: ScaLAPACK not used, ", Nd0, " <= ", scalapackThreshold
                 End If
-            
+
                 Select Case(type_real)
                 Case(sp)
                     Call SSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
                 Case(dp)
                     Call DSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
                 End Select
-            
+
                 lwork = Nint(realtmp(1))
-            
+
                 Allocate(W(lwork))
                 If (isVerbose) Write(*,"(A,I12)") "DiagInitApprox: Work array allocated, real=", lwork
                 Select Case(type_real)

--- a/src/pconf.f90
+++ b/src/pconf.f90
@@ -62,15 +62,17 @@ Program pconf
     use formj2, only : FormJ
     Use str_fmt, Only : startTimer, stopTimer, FormattedTime
     Use env_var
-
+    
     Implicit None
     External :: BLACS_PINFO, BLACS_EXIT
-    Integer   :: n, nnd, i, ierr, mype, npes, mpierr, threadLevel
-    Integer :: ncsf, nccj, max_ndcs, nbas
+    Integer   :: n, i, ierr, mype, npes, mpierr, threadLevel
     Integer(kind=int64) :: start_time
-    Character(Len=255)  :: eValue, strfmt
+    Character(Len=255)  :: strfmt
     Character(Len=16)   :: timeStr
     Real(dp), Allocatable, Dimension(:) :: xj, xl, xs, ax_array
+
+    Type(MPI_Datatype) :: mpi_type_real
+    Type(MPI_Datatype) :: mpi_type2_real
 
     ! Initialize MPI
     Call MPI_Init_thread(MPI_THREAD_SINGLE, threadLevel, mpierr)
@@ -139,7 +141,7 @@ Program pconf
     
     ! Davidson diagonalization
     Call Diag4(mype,npes) 
-    
+
     ! Print table of final energies
     If (mype==0) Call PrintEnergies
 
@@ -155,14 +157,10 @@ Program pconf
     ! Print table of final results and total computation time
     If (mype==0) Then
         Call PrintWeights
+        Close(11)
         
         Call stopTimer(start_time, timeStr)
-        write(*,'(2X,A)'), 'TIMING >>> Total computation time of conf was '// trim(timeStr)
-    End If
-
-    ! In rank 0, close-out unit 11
-    If (mype == 0) Then
-        Close(11)
+        write(*,'(2X,A)') 'TIMING >>> Total computation time of conf was '// trim(timeStr)
     End If
 
     ! All done: 
@@ -268,8 +266,10 @@ Contains
     End Subroutine Input
 
     Subroutine Init
+        Use utils, Only : DetermineRecordLength
+
         Implicit None
-        Integer  :: ic, n, j, imax, ni, ni2, kkj, llj, nnj, i, nj, nr, if, &
+        Integer  :: ic, n, j, imax, ni, ni2, kkj, llj, nnj, i, nj, nr, nf, &
                     ii, i1, n2, n1, l, nmin, jlj, i0, nlmax, err_stat
         Real(dp) :: d, c1, c2, z1
         Real(dp), Dimension(IP6)  :: p, q, p1, q1 
@@ -277,7 +277,7 @@ Contains
         Integer, Dimension(0:33)  ::  nnn ,jjj ,nqq, nnn1, qqq1, nnn2, qqq2
         Character(Len=1), Dimension(9) :: Let 
         Character(Len=1), Dimension(0:33):: lll, lll1, lll2
-        logical :: longbasis
+        Logical :: longbasis, success
         Integer, Dimension(4*IPs) :: IQN
         Real(dp), Dimension(IPs)  :: Qq1
         Character(Len=256) :: strfmt, err_msg
@@ -287,9 +287,26 @@ Contains
         Data Let/'s','p','d','f','g','h','i','k','l'/
 
         c1 = 0.01d0
-        mj = 2*dabs(Jm)+0.01d0
+        mj = Int(2*dabs(Jm)+0.01d0)
 
-        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        nnn=0
+        jjj=0
+        nqq=0
+        nnn1=0
+        qqq1=0
+        nnn2=0
+        qqq2=0
+        lll=''
+        lll1=''
+        lll2=''
+
+        Call DetermineRecordLength(Mrec, success)
+        If (.not. success) Then
+            Write(*,*) 'ERROR: record length could not be determined'
+            Stop
+        End If
+
+        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             strfmt='(/2X,"file CONF.DAT is absent"/)'
             Write( *,strfmt)
@@ -312,8 +329,8 @@ Contains
 
         Allocate(Nvc(Nc),Nc0(Nc),Nq(Nsp),Nip(Nsp))
         Allocate(Nrnrc(Nc))
-        Ns = pq(2)+c1
-        ii = pq(3)+c1
+        Ns = Int(pq(2)+c1)
+        ii = Int(pq(3)+c1)
         Rnuc=pq(13)
         dR_N=pq(16)
         
@@ -333,34 +350,34 @@ Contains
                 Jj(ni)=IQN(4*ni)
             End Do
         Else
-            if=20
+            nf=20
             Do ni=1,Ns
-                if=if+1
-                Nn(ni)=pq(if)+c1
-                if=if+1
-                Ll(ni)=pq(if)+c1
-                if=if+3
-                c2=dsign(c1,pq(if))
-                Kk(ni)=pq(if)+c2
-                if=if+1
-                c2=dsign(c1,pq(if))
-                Jj(ni)=pq(if)+c2
+                nf=nf+1
+                Nn(ni)=Int(pq(nf)+c1)
+                nf=nf+1
+                Ll(ni)=Int(pq(nf)+c1)
+                nf=nf+3
+                c2=dsign(c1,pq(nf))
+                Kk(ni)=Int(pq(nf)+c2)
+                nf=nf+1
+                c2=dsign(c1,pq(nf))
+                Jj(ni)=Int(pq(nf)+c2)
             End Do
         End If
 
         Nsu=0
         Do nj=1,Nsp
-            i=sign(1.d0,Qnl(nj))
+            i=Int(sign(1.d0,Qnl(nj)))
             d=dabs(Qnl(nj))+1.d-14
             d=10.0*d
-            nnj=d
+            nnj=Int(d)
             d=10.0d0*(d-nnj)
-            llj=d
+            llj=Int(d)
             jlj=2*llj+i
             kkj=-i*((jlj+1)/2)
             d=100.0d0*(d-llj)
-            Nq(nj)=d+0.1d0
-            Do ni=1,ns
+            Nq(nj)=Int(d+0.1d0)
+            Do ni=1,Ns
                 If (nnj == Nn(ni) .and. Kk(ni) == kkj) Then
                     Exit
                 Else If (ni == ns) Then
@@ -602,7 +619,7 @@ Contains
                 Iint1S(i)=ind
                 Rsig(i)=x
                 Dsig(i)=y
-                Esig(i)=z
+                Esig(i)=Real(z, kind=type2_real)
             End Do
         End Do
         xscr=10.d0
@@ -827,10 +844,12 @@ Contains
     
         Call calcMemStaticArrays
         Call FormattedMemSize(memStaticArrays, memStr)
-        Write(*,'(A,A,A)') 'calcMemReqs: Allocating static arrays will require at least ',Trim(memStr),' of memory per core. (These will not be deallocated)' 
+        Write(*,'(A,A,A)') 'calcMemReqs: Allocating static arrays will require at least ',Trim(memStr), &
+                            ' of memory per core. (These will not be deallocated)' 
 
         Call FormattedMemSize(memFormH, memStr)
-        Write(*,'(A,A,A)') 'calcMemReqs: Allocating arrays for FormH will require at least ',Trim(memStr),' of memory per core' 
+        Write(*,'(A,A,A)') 'calcMemReqs: Allocating arrays for FormH will require at least ',Trim(memStr), &
+                            ' of memory per core' 
         
         memEstimate = memFormH + memStaticArrays
     
@@ -917,7 +936,7 @@ Contains
         Else
             count = Ngint*2_int64
         End If
-        Call BroadcastD(Rint2, count, 0, 0, MPI_COMM_WORLD, mpierr)
+        Call BroadcastD(Rint2, count, 0, mpi_type2_real, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(Iint1, Nhint, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint2, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint3, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
@@ -1081,7 +1100,7 @@ Contains
                                     Call Rspq_phase2(idet1, idet2, iSign, diff, iIndexes, jIndexes)
                                     If (Kdsig /= 0 .and. diff <= 2) E_k=Diag(kk)
                                     tt=Hmltn(idet1, iSign, diff, jIndexes(3), iIndexes(3), jIndexes(2), iIndexes(2))
-                                    If (tt /= 0) Then
+                                    If (tt /= 0_type_real) Then
                                         cntarray = cntarray + 1
                                         Call IVAccumulatorAdd(iva1, nn)
                                         Call IVAccumulatorAdd(iva2, kk)
@@ -1111,7 +1130,6 @@ Contains
                     Call MPI_RECV( cntarray, 3, MPI_INTEGER, MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, status, mpierr)
                     sender = status%MPI_SOURCE
              
-                    !If (devmode == 1) print*, cntarray(3), cntarray(1), sender
                     If (nnd + ndGrowBy <= Nd) Then
                         nnd = nnd + ndGrowBy
                         Call MPI_SEND( nnd, 1, MPI_INTEGER, sender, send_tag, MPI_COMM_WORLD, mpierr)
@@ -1135,11 +1153,12 @@ Contains
                         Call FormattedMemSize(maxmem, memStr2)
                         Call FormattedMemSize(NumH*(8+type_real), memStr3)
                         Write(counterStr,fmt='(I16)') NumH
-                        Write(*,'(2X,A,1X,I3,A)'), 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
+                        Write(*,'(2X,A,1X,I3,A)') 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
                                                     Trim(AdjustL(counterStr)) // ' elements'
-                        Write(*,'(4X,A)'), 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// trim(memStr2)//')'
+                        Write(*,'(4X,A)') 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// &
+                                            trim(memStr2)//')'
                         If (memTotalPerCPU /= 0 .and. statmem > memTotalPerCPU) Then
-                            Write(*,'(A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
+                            Write(*,'(A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
                                                     Trim(memTotStr2) ,' is available.'
                             Stop
                         End If
@@ -1158,22 +1177,23 @@ Contains
                         memEstimate = memEstimate + maxmem
                         Write(counterStr,fmt='(I16)') NumH
                         Call FormattedMemSize(mem, memStr)
-                        Write(*,'(2X,A,1X,I3,A)'), 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
+                        Write(*,'(2X,A,1X,I3,A)') 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
                                                     Trim(AdjustL(counterStr)) // ' elements'
-                        Write(*,'(4X,A)'), 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// trim(memStr2)//')'
-                        Write(*,'(A)'), 'SUMMARY - (total = '// trim(memStr) // ', static = ' // trim(memStr4) &
+                        Write(*,'(4X,A)') 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// &
+                                            trim(memStr2)//')'
+                        Write(*,'(A)') 'SUMMARY - (total = '// trim(memStr) // ', static = ' // trim(memStr4) &
                                             // ', davidson = ' // trim(memStr5) // ', Hamiltonian = ' // trim(memStr2) // ')'
                         If (memTotalPerCPU /= 0) Then
                             If (statmem > memTotalPerCPU) Then
-                                Write(*,'(A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
+                                Write(*,'(A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
                                                         Trim(memTotStr2) ,' is available.'
                                 Stop
                             Else If (statmem < memTotalPerCPU) Then
-                                Write(*,'(A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, and ' , &
+                                Write(*,'(A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, and ' , &
                                                         Trim(memTotStr2) ,' is available.'
                             End If
                         Else
-                            Write(*,'(2X,A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, &
+                            Write(*,'(2X,A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, &
                                                         but available memory was not saved to environment'
                         End If
                         Exit
@@ -1264,7 +1284,7 @@ Contains
                     If (Kl /=3 .and. t == 0) numzero=numzero+1
                     If (counter1 == maxNumElementsPerCore .and. mod(n8,mesplit)==0) Then
                         Call stopTimer(s1, timeStr)
-                        Write(*,'(2X,A,1X,I3,A)'), 'FormH calculation stage:', j*10, '% done in '// trim(timeStr)
+                        Write(*,'(2X,A,1X,I3,A)') 'FormH calculation stage:', j*10, '% done in '// trim(timeStr)
                         j=j+1
                     End If
                 End Do
@@ -1279,7 +1299,7 @@ Contains
         End If
 
         ih8=size(Hamil%val, kind=int64)
-        ih4=ih8
+        ih4=Int(ih8, kind=int32)
         
         Call MPI_AllReduce(ih8, NumH, 1, MPI_INTEGER8, MPI_SUM, MPI_COMM_WORLD, mpierr)
         Call MPI_AllReduce(MPI_IN_PLACE, numzero, 1, MPI_INTEGER8, MPI_SUM, MPI_COMM_WORLD, mpierr)
@@ -1330,7 +1350,7 @@ Contains
         ! Stop timer and output computation time of FormH 
         If (mype == 0) Then
             Call stopTimer(stot, timeStr)
-            write(*,'(2X,A)'), 'TIMING >>> FormH took '// trim(timeStr) // ' to complete'
+            write(*,'(2X,A)') 'TIMING >>> FormH took '// trim(timeStr) // ' to complete'
         End If
 
         Return
@@ -1340,7 +1360,7 @@ Contains
         ! This function calculates the Hamiltonian matrix element between determinants idet1 and idet2
         Use determinants, Only : Rspq
         Use integrals, Only : Gint, Hint
-        Use formj2, Only : F_J0, F_J2
+        Use formj2, Only : F_J2
         Implicit None
         Integer, Allocatable, Dimension(:), Intent(InOut)   :: idet
         Integer, Intent(InOut)                              :: is, nf, i1, i2, j1, j2
@@ -1423,13 +1443,14 @@ Contains
         Implicit None
         Integer :: mpierr, mype
         Character(Len=16) :: memStr, memTotStr
+
         Call MPI_Barrier(MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(Nd0, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         If (.not. Allocated(ArrB)) Allocate(ArrB(Nd,IPlv))
         If (.not. Allocated(Tk)) Allocate(Tk(Nlv))
         If (.not. Allocated(Tj)) Allocate(Tj(Nlv))
         If (.not. Allocated(P)) Allocate(P(2*Nlv,2*Nlv))
-        If (.not. Allocated(E)) Allocate(E(Nlv))
+        If (.not. Allocated(E)) Allocate(E(2*Nlv))
         If (.not. Allocated(Iconverge)) Allocate(Iconverge(Nlv))
         If (.not. Allocated(B1)) Allocate(B1(Nd))
         If (.not. Allocated(B2)) Allocate(B2(Nd))
@@ -1457,15 +1478,15 @@ Contains
             Call FormattedMemSize(memTotalPerCPU, memTotStr)
             If (memTotalPerCPU /= 0) Then
                 If (memEstimate > memTotalPerCPU) Then
-                    Write(*,'(A,A,A,A)'), 'At least '// Trim(memStr), ' is required to finish conf, but only ', &
+                    Write(*,'(A,A,A,A)') 'At least '// Trim(memStr), ' is required to finish conf, but only ', &
                                             Trim(memTotStr) ,' is available.'
                     Stop
                 Else If (memEstimate < memTotalPerCPU) Then
-                    Write(*,'(A,A,A,A)'), 'At least '// Trim(memStr), ' is required to finish conf, and ' , &
+                    Write(*,'(A,A,A,A)') 'At least '// Trim(memStr), ' is required to finish conf, and ' , &
                                             Trim(memTotStr) ,' is available.'
                 End If
             Else
-                Write(*,'(2X,A,A,A,A)'), 'At least '// Trim(memStr), ' is required to finish conf, &
+                Write(*,'(2X,A,A,A,A)') 'At least '// Trim(memStr), ' is required to finish conf, &
                                             but available memory was not saved to environment'
             End If
         End If   
@@ -1476,10 +1497,13 @@ Contains
         Use mpi_f08
         Use str_fmt, Only : startTimer, stopTimer, FormattedTime
         Use env_var
-        Implicit None
-        External :: INFOG2L, PDELGET, SSYEV, DSYEV, BLACS_GET, BLACS_GRIDINIT, BLACS_GRIDINFO, BLACS_GRIDEXIT, BLACS_EXIT, NUMROC, DESCINIT, PDELSET, PDSYEVD, PSSYEVD, PSELSET
 
-        Integer :: I, J, lwork, mype, npes, ifail, srcRow, srcCol
+        Implicit None
+        
+        External :: INFOG2L, PDELGET, SSYEV, DSYEV, BLACS_GET, BLACS_GRIDINIT, BLACS_GRIDINFO, BLACS_GRIDEXIT, &
+                    BLACS_EXIT, NUMROC, DESCINIT, PDELSET, PDSYEVD, PSSYEVD, PSELSET
+
+        Integer :: I, J, lwork, mype, npes, ifail
         Integer :: NPROW, NPCOL, CONTEXT, MYROW, MYCOL, LIWORK, NROWSA, NCOLSA, NUMROC
         Integer(Kind=int64) :: s1, scalapackThreshold
         Integer(Kind=int64), Dimension(2) :: blacsGrid
@@ -1490,12 +1514,11 @@ Contains
         Integer, Allocatable, Dimension(:)     :: IWORK ! integer work array
         Real(type_real), Allocatable, Dimension(:)    :: W     ! double precision work array
         Real(type_real), Allocatable, Dimension(:,:)  :: A, Z
-        Character(len=48) :: blacsGridSpec
 
         If (mype == 0) Then
             ! At what point should we switch to the BLACS/ScaLAPACK algorithm?  The default
             ! value 10240 is just a guess and equates with an 800 MiB Z1:
-            scalapackThreshold = GetEnvInteger64("CONF_DIAG_INIT_APPROX_THRESHOLD", 10240)
+            scalapackThreshold = GetEnvInteger64("CONF_DIAG_INIT_APPROX_THRESHOLD", 10240_int64)
             isVerbose = GetEnvLogical("CONF_DIAG_INIT_APPROX_VERBOSE", .false.)
             shouldForceSerial = GetEnvLogical("CONF_DIAG_INIT_APPROX_FORCE_SERIAL", .false.)
             shouldForceScalapack = GetEnvLogical("CONF_DIAG_INIT_APPROX_FORCE_SCALAPACK", .false.)
@@ -1517,24 +1540,29 @@ Contains
                 Else
                     Write(*,"(A,I12,A,I12)") "DiagInitApprox: ScaLAPACK not used, ", Nd0, " <= ", scalapackThreshold
                 End If
+
+                Select Case(type_real)
+                Case(sp)
+                    Call SSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
+                Case(dp)
+                    Call DSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
+                End Select
+
+                lwork = Nint(realtmp(1))
+
+                Allocate(W(lwork))
+                If (isVerbose) Write(*,"(A,I12)") "DiagInitApprox: Work array allocated, real=", lwork
+                Select Case(type_real)
+                Case(sp)
+                    Call SSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
+                Case(dp)
+                    Call DSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
+                End Select
+                If (isVerbose) Write(*,"(A)") "DiagInitApprox: Eigenvalues and -vectors calculated"
+                Deallocate(W)
             End If
-            Select Case(type_real)
-            Case(sp)
-                Call SSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
-            Case(dp)
-                Call DSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
-            End Select
-            lwork = Nint(realtmp(1))
-            Allocate(W(lwork))
-            If (mype==0 .and. isVerbose) Write(*,"(A,I12)") "DiagInitApprox: Work array allocated, real=", lwork
-            Select Case(type_real)
-            Case(sp)
-                Call SSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
-            Case(dp)
-                Call DSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
-            End Select
-            If (mype==0 .and. isVerbose) Write(*,"(A)") "DiagInitApprox: Eigenvalues and -vectors calculated"
-            Deallocate(W)
+            Call MPI_Bcast(Z1, Nd0*Nd0, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, mpierr)
+            Call MPI_Bcast(E1, Nd0, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, mpierr)
         Else
             If (mype==0) Write(*,"(A,I5,A)") "DiagInitApprox: ScaLAPACK used, will distribute across ", npes, " cpus"
             NPROW=1
@@ -1544,20 +1572,23 @@ Contains
             CALL BLACS_GET(-1, 0, CONTEXT)
             CALL BLACS_GRIDINIT(CONTEXT, 'R', NPROW, NPCOL)
             CALL BLACS_GRIDINFO(CONTEXT, NPROW, NPCOL, MYROW, MYCOL)
-            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: BLACS grid init, rank ", mype, " -> ", MYROW,  ",", MYCOL
+            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: BLACS grid init, rank ", &
+                                                            mype, " -> ", MYROW,  ",", MYCOL
 
             ! Calculate the number of rows, NROWSA, and the number of columns, NCOLSA, for the local matrices A
             If (mype==0) Then
                 blacsGrid(1) = GetEnvInteger("CONF_DIAG_INIT_APPROX_BLACS_ROWS", Nd0)
                 blacsGrid(2) = GetEnvInteger("CONF_DIAG_INIT_APPROX_BLACS_COLS", 1)
-                If (isVerbose) Write(*,"(A,I5,A,I5,A)") "DiagInitApprox: BLACS grid will be ", blacsGrid(1), " rows by ", blacsGrid(2), " columns"
+                If (isVerbose) Write(*,"(A,I5,A,I5,A)") "DiagInitApprox: BLACS grid will be ", blacsGrid(1), &
+                                                        " rows by ", blacsGrid(2), " columns"
             End If
             Call MPI_Bcast(blacsGrid, 2, MPI_INTEGER8, 0, MPI_COMM_WORLD, mpierr)
             
             NROWSA = NUMROC(Nd0,blacsGrid(1),MYROW,0,NPROW)
             NCOLSA = NUMROC(Nd0,blacsGrid(2),MYCOL,0,NPCOL)
             ALLOCATE(A(NROWSA,NCOLSA), Z(NROWSA,NCOLSA))
-            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated local storage, rank ", mype, " -> ", NROWSA,  " x ", NCOLSA
+            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated local storage, rank ", &
+                                                            mype, " -> ", NROWSA,  " x ", NCOLSA
 
             ! Initialize array descriptors DESCA and DESCZ
             CALL DESCINIT(DESCA, Nd0, Nd0, blacsGrid(1), blacsGrid(2), 0, 0, CONTEXT, NROWSA, ifail)
@@ -1594,7 +1625,8 @@ Contains
             LWORK = realtmp(1)
             LIWORK = itmp(1)
             ALLOCATE(IWORK(LIWORK), W(LWORK))
-            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated work arrays, rank ", mype, " -> real=", LWORK,  ", integer=", LIWORK
+            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated work arrays, rank ", mype, &
+                                                            " -> real=", LWORK,  ", integer=", LIWORK
 
             ! Compute the eigenvalues E1 and eigenvectors Z
             Select Case(type_real)
@@ -1624,7 +1656,7 @@ Contains
         If (mype==0) Then
             ! Stop timer and print time for initial diagonalization
             Call stopTimer(s1, timeStr)
-            Write(*,"(2X,A,A,A)"), "TIMING >>> Initial diagonalization took ", trim(timeStr), " to complete"
+            Write(*,"(2X,A,A,A)") "TIMING >>> Initial diagonalization took ", trim(timeStr), " to complete"
         End If
         Call MPI_Barrier(MPI_COMM_WORLD, mpierr)
     End Subroutine DiagInitApprox
@@ -1640,21 +1672,20 @@ Contains
         Implicit None
         External :: DSYEV, SSYEV
 
-        Integer  :: k1, k, i, n1, kx, i1, it, js, mype, npes, mpierr, ifail=0, lwork
+        Integer  :: k1, k, i, n1, kx, i1, it, mype, npes, mpierr, ifail, lwork
         Real(kind=type_real), Dimension(4) :: realtmp
         Real(kind=type_real), Allocatable, Dimension(:) :: W ! work array
         Integer(Kind=int64) :: start_time, s1
         Real(type_real)  :: crit, ax, x, xx, vmax
         Real(dp) :: cnx
         Character(Len=16) :: timeStr, iStr
-        Integer,  Allocatable, Dimension(:) :: Jn, Jk
-        Real(kind=type_real), Allocatable, Dimension(:) :: Jv
 
         ! Initialize parameters and arrays
         Iconverge = 0
         crit=1.d-6
         ax=1.d0
         cnx=1.d0
+        ifail=0
         If (.not. Allocated(ax_array)) Allocate(ax_array(Nlv))
 
         ! Start timer for Davidson procedure
@@ -1668,13 +1699,13 @@ Contains
         End If
 
         ! Construct initial approximation from Hamiltonian matrix
-        Call Init4(mype)
+        Call Init4(mype, mpi_type_real)
 
         ! Diagonalize the initial approximation 
         Call DiagInitApprox(mype, npes)
 
         ! Write initial approximation to file CONF.XIJ
-        Call FormB0(mype)
+        Call FormB0(mype, mpi_type_real)
         
         ! Set up work array for diagonalization of energy matrix P during iterative procedure
         If (mype == 0) Then
@@ -1687,15 +1718,6 @@ Contains
             End Select
             lwork = Nint(realtmp(1))
             Allocate(W(lwork))
-        End If
-
-        ! temporary solution for value of Jsq%ind1 changing during LAPACK ZSYEV subroutine
-        If (mype == 0) Then
-            js = size(Jsq%ind1)
-            Allocate(Jn(js),Jk(js),Jv(js))
-            Jn=Jsq%ind1
-            Jk=Jsq%ind2
-            Jv=Jsq%val
         End If
 
         ! Davidson loop:
@@ -1728,7 +1750,7 @@ Contains
                 End If
 
                 ! Formation of the left-upper block of the energy matrix P
-                Call Mxmpy(1, mype)
+                Call Mxmpy(1, mpi_type_real, mype)
                 If (mype==0) Then 
                     Call stopTimer(s1, timeStr)
                     Write(77,*) 'Mxmpy1 took ' // timeStr
@@ -1756,13 +1778,9 @@ Contains
                     Call stopTimer(s1, timeStr)
                     Write(77,*) 'Formation of Nlv additional probe vectors took' // timeStr
                 End If
+                
                 If (K_prj == 1) Then
-                    If (mype == 0) Then
-                        Jsq%ind1=Jn
-                        Jsq%ind2=Jk
-                        Jsq%val=Jv
-                    End If
-                    Call Prj_J(Nlv+1,Nlv,2*Nlv+1,1.d-5,mype)
+                    Call Prj_J(Nlv+1,Nlv,2*Nlv+1,1.d-5,mpi_type_real, mype)
                     If (mype == 0) Then
                         Call startTimer(s1)
                         Do i=Nlv+1,2*Nlv
@@ -1785,11 +1803,12 @@ Contains
                         Write(77,*) 'Orthogonalization of Nlv additional probe vectors took ' // timeStr
                     End If
                 End If
+                
                 Call MPI_Bcast(cnx, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, mpierr)
                 If (cnx > Crt4) Then
                     ! Formation of other three blocks of the matrix P:
                     Call startTimer(s1)
-                    Call Mxmpy(2, mype)
+                    Call Mxmpy(2, mpi_type_real, mype)
                     If (mype==0) Then
                         Call stopTimer(s1, timeStr)
                         Write(77,*) 'Mxmpy2 took ' // timeStr
@@ -1797,8 +1816,7 @@ Contains
                         Call FormP(2, vmax)
                         Call stopTimer(s1, timeStr)
                         Write(77,*) 'FormP2 took ' // timeStr
-                        ! >>>>> this block of code causes problem allocating xj, xl, xs arrays >>>>>
-                        ! >>>>>>>>>>>>>>>> if allocation occurs after this block >>>>>>>>>>>>>>>>>>>
+
                         ! Evaluation of Nlv eigenvectors:
                         Call startTimer(s1)
                         Select Case(type_real)
@@ -1807,7 +1825,6 @@ Contains
                         Case(dp)
                             Call DSYEV('V','U',n1,P,n1,E,W,lwork,ifail)
                         End Select
-                        ! <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                         Call stopTimer(s1, timeStr)
                         Write(77,*) 'Nlv eigenvectors evaluated in ' // timeStr
                         
@@ -1841,12 +1858,7 @@ Contains
                             ! Calculate J for each energy level
                             Do n=1,Nlv
                                 Call MPI_Bcast(ArrB(1:Nd,n), Nd, mpi_type_real, 0, MPI_COMM_WORLD, mpierr)
-                                If (mype == 0) Then
-                                    Jsq%ind1=Jn
-                                    Jsq%ind2=Jk
-                                    Jsq%val=Jv
-                                End If
-                                Call J_av(ArrB(1,n),Nd,Tj(n),ierr)  ! calculates expectation values for J^2
+                                Call J_av(ArrB(1,n),Nd,Tj(n),mpi_type_real,ierr)  ! calculates expectation values for J^2
                             End Do
                             If (mype == 0) Then
                                 Call FormB
@@ -1878,21 +1890,12 @@ Contains
             End If
         End Do
 
-        ! temporary solution for value of Jsq%ind1 changing during LAPACK ZSYEV subroutine
-        If (mype == 0) Then
-            Jsq%ind1=Jn
-            Jsq%ind2=Jk
-            Jsq%val=Jv
-            If (allocated(Jn)) Deallocate(Jn)
-            If (allocated(Jk)) Deallocate(Jk)
-            If (allocated(Jv)) Deallocate(Jv)
-        End If
         ! Write final eigenvalues and eigenvectors to file CONF.XIJ
         Call WriteFinalXIJ(mype)
 
         If (mype == 0) Then
             Call stopTimer(start_time, timeStr)
-            Write(*,'(2X,A)'), 'TIMING >>> Davidson procedure took '// trim(timeStr) // ' to complete'
+            Write(*,'(2X,A)') 'TIMING >>> Davidson procedure took '// trim(timeStr) // ' to complete'
             Close(77)
         End If
 
@@ -2005,13 +2008,13 @@ Contains
         Real(dp), Allocatable, Dimension(:)  :: C
         Real(dp), Allocatable, Dimension(:,:)  :: Weights, W2, Wsave
         Character(Len=512) :: strfmt, strconfig, strsp
-        Character(Len=64), Allocatable, Dimension(:,:) :: strcsave
+        Character(Len=512), Allocatable, Dimension(:,:) :: strcsave
         Character(Len=3) :: strc, strq
         Integer, Dimension(0:33)  ::  nnn, nqq 
         Character(Len=1), Dimension(9) :: Let 
         Character(Len=1), Dimension(0:33):: lll
         Type WeightTable
-            Character(Len=64), Allocatable, Dimension(:) :: strconfs, strconfsave
+            Character(Len=512), Allocatable, Dimension(:) :: strconfs, strconfsave
             Integer, Allocatable, Dimension(:) :: nconfs, nconfsave
             Real(dp), Allocatable, Dimension(:) :: wgt, wgtsave
         End Type WeightTable
@@ -2102,7 +2105,8 @@ Contains
                     Else
                         strq = ''
                     End If
-                    strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
+                    strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // &
+                                Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
                 End Do
                 strcsave(k,j) = strconfig
             End Do
@@ -2151,8 +2155,10 @@ Contains
                     wgtconfs%strconfs(k) = strcsave(i,j)
                     k = k + 1
                 End If
-                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
-                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
+                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
+                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
                 wsum = wsum + Wsave(i,j)
             End Do
             Write(98,'(A)') '_______'
@@ -2207,16 +2213,13 @@ Contains
         Implicit None
         Integer :: i, n, ierr, mype, mpierr
 
-        !If (K_prj == 1) Then
-        !    Call Prj_J(1,Nlv,Nlv+1,1.d-8,mype)
-        !End If
         If (mype == 0) Then
             open(unit=17,file='CONF.XIJ',status='OLD',form='UNFORMATTED')
         End If
         
         Do n=1,Nlv
             Call MPI_Bcast(ArrB(1:Nd,n), Nd, mpi_type_real, 0, MPI_COMM_WORLD, mpierr)
-            Call J_av(ArrB(1,n),Nd,Tj(n),ierr)  ! calculates expectation values for J^2
+            Call J_av(ArrB(1,n),Nd,Tj(n),mpi_type_real,ierr)  ! calculates expectation values for J^2
             If (mype==0) Then
                 write(17) Tk(n),Tj(n),Nd,(ArrB(i,n),i=1,Nd)
             End If
@@ -2366,14 +2369,14 @@ Contains
 
                     If (nnc == nccnt .and. nnc /= ncsplit*10) Then
                         Call stopTimer(s1, timeStr)
-                        If (moreTimers == .true.) Write(*,'(2X,A,1X,I3,A)'), 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
+                        If (moreTimers) Write(*,'(2X,A,1X,I3,A)') 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
                         j=j-1
                         nccnt = nccnt + ncsplit
                     End If
 
                     If (num_done == npes-1) Then
                         Call stopTimer(s1, timeStr)
-                        If (moreTimers == .true.) Write(*,'(2X,A,1X,I3,A)'), 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
+                        If (moreTimers) Write(*,'(2X,A,1X,I3,A)') 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
                         Exit
                     End If
                 End Do
@@ -2835,7 +2838,8 @@ Contains
     Subroutine PrintWeights
         ! This subroutine prints the weights of configurations
         Implicit None
-        Integer :: j, k, j1, j2, j3, ic, i, ii, i1, l, n0, n1, n2, ni, nk, ndk, m1, nspaces, nspacesg, nconfs, cnt, nspacesterm, maxlenconfig, num_blanks, num_blanks2
+        Integer :: j, k, j1, j2, j3, ic, i, i1, l, n0, n1, n2, ni, nk, ndk, m1, nspaces, nspacesg, &
+                    nconfs, cnt, nspacesterm, maxlenconfig, num_blanks, num_blanks2
         Real(dp) :: wsum, gfactor, ax_crit, j_crit
         Integer, Allocatable, Dimension(:,:) :: Wpsave
         Real(dp), Allocatable, Dimension(:)  :: C
@@ -2972,7 +2976,8 @@ Contains
                     If (strconfig == '') Then
                         strconfig = Trim(AdjustL(strc)) // Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
                     Else
-                        strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
+                        strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // &
+                                    Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
                     End If
                 End Do
                 strcsave(k,j) = strconfig
@@ -3032,25 +3037,31 @@ Contains
                 ! Write column names if first iteration
                 If (j == 1) Then
                     num_blanks = max(0, maxlenconfig-3)
-                    Write(99, '(A)') '  n' // '  ' // repeat(' ', num_blanks) // 'conf  term     E_n (a.u.)   DEL (cm^-1)     S     L     J     gf     conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
+                    Write(99, '(A)') '  n' // '  ' // repeat(' ', num_blanks) // 'conf  term     E_n (a.u.)   DEL (cm^-1) &
+                                        S     L     J     gf     conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
                 End If
                 ! If main configuration has weight of less than 0.7, we have to include a secondary configuration
                 num_blanks = max(0, maxlenconfig-len_trim(strcsave(1,j))+1)
                 If (Wsave(1,j) < 0.7) Then
                     num_blanks2 = max(0, maxlenconfig-len_trim(strcsave(2,j))+1)
                     strfmt = '(I3,3X,A,A,1X,f14.8,f14.1,2X,f4.2,2x,f4.2,2x,f4.2,2x,A,4x,f4.1,"%",5X,A,2X,A,3X,f5.1,"%")'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), Tk(j), (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, Wsave(1,j)*100, strconverged, repeat(' ', num_blanks2) // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), Tk(j), &
+                                     (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, Wsave(1,j)*100, strconverged, &
+                                     repeat(' ', num_blanks2) // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
                 ! Else we include only the main configuration
                 Else
                     strfmt = '(I3,3X,A,A,1X,f14.8,f14.1,2X,f4.2,2x,f4.2,2x,f4.2,2x,A,4x,f5.1,"%",5X,A)'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), Tk(j), (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, maxval(W2(1:Nnr,j))*100, strconverged
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), &
+                                        Tk(j), (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, maxval(W2(1:Nnr,j))*100, &
+                                        strconverged
                 End If
             ! If L, S, J is not needed
             Else
                 ! Write column names if first iteration
                 If (j == 1) Then
                     num_blanks = max(0, maxlenconfig-3)
-                    Write(99, '(A)') '  n ' // '  ' // repeat(' ', num_blanks) // 'conf       J         E_n (a.u.)   DEL (cm^-1)    conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
+                    Write(99, '(A)') '  n ' // '  ' // repeat(' ', num_blanks) // 'conf       J         E_n (a.u.)  &
+                                         DEL (cm^-1)    conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
                 End If
 
                 ! If main configuration has weight of less than 0.7, we have to include a secondary configuration
@@ -3058,11 +3069,14 @@ Contains
                 If (Wsave(1,j) < 0.7) Then
                     num_blanks2 = max(0, maxlenconfig-len_trim(strcsave(2,j))+1)
                     strfmt = '(I3,4X,A,4X,f4.2,5x,f14.8,f14.1,3X,f4.1,"%",,5X,A,2X,A,3X,f5.1,"%")'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), (Tk(1)-Tk(j))*2*DPRy, Wsave(1,j)*100, strconverged, repeat(' ', num_blanks2) // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), &
+                                        (Tk(1)-Tk(j))*2*DPRy, Wsave(1,j)*100, strconverged, repeat(' ', num_blanks2) &
+                                        // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
                 ! Else we include only the main configuration
                 Else
                     strfmt = '(I3,4X,A,4X,f4.2,5x,f14.8,f14.1,3X,f5.1,"%",5X,A)'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), (Tk(1)-Tk(j))*2*DPRy, maxval(W2(1:Nnr,j))*100, strconverged
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), &
+                                        (Tk(1)-Tk(j))*2*DPRy, maxval(W2(1:Nnr,j))*100, strconverged
                 End If
             End If 
         End Do
@@ -3099,8 +3113,10 @@ Contains
                     wgtconfs%strconfs(k) = strcsave(i,j)
                     k = k + 1
                 End If
-                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
-                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
+                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
+                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
                 wsum = wsum + Wsave(i,j)
             End Do
             Write(98,'(A)') '_______'
@@ -3197,9 +3213,16 @@ Contains
             End Do
             Write(11,strfmt) (st1,i=j1,j3)
         End Do
-        Deallocate(C, W, W2, Wsave, Wpsave, strcsave, Ndc, Tk, Tj, ArrB)
-        Close(11)
-        
+
+        If (Allocated(W)) Deallocate(W)
+        If (Allocated(W2)) Deallocate(W2)
+        If (Allocated(Wsave)) Deallocate(Wsave)
+        If (Allocated(Wpsave)) Deallocate(Wpsave)
+        If (Allocated(strcsave)) Deallocate(strcsave)
+        If (Allocated(Ndc)) Deallocate(Ndc)
+        If (Allocated(Tk)) Deallocate(Tk)
+        If (Allocated(ArrB)) Deallocate(ArrB)
+                
     End Subroutine PrintWeights
 
     Character(Len=6) Function term(L, S, J)

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -362,18 +362,18 @@ Contains
 
         Select Case(Kl1)
             Case(1) ! regime of Density matrix & expectation values
-                strfmt = '(/4X,"Program pdtm v4.0: Density matrices",/4X,"Cutoff parameter :",E8.1, &
+                strfmt = '(/4X,"Program pdtm v4.1: Density matrices",/4X,"Cutoff parameter :",E8.1, &
                     /4X,"Full RES file - ",A3,/4X,"DM0.RES file - ",A3, &
                     /4X,"Do you want DM (1) OR TM (2)? ",I1)'
                 Call OpenFS('DM.RES',0,11,1)
                 Iprt=+1      !### parity of the transition
             Case(2) ! regime of Transition matrix & amplitudes
-                strfmt = '(/4X,"Program pdtm v4.0: Transition matrices",/4X,"Cutoff parameter :",E8.1, &
+                strfmt = '(/4X,"Program pdtm v4.1: Transition matrices",/4X,"Cutoff parameter :",E8.1, &
                     /4X,"Full RES file - ",A3,/4X,"DM0.RES file - ",A3, &
                     /4X,"Do you want DM (1) OR TM (2)? ",I1)'
                 Call OpenFS('TM.RES',0,11,1)
             Case(3) ! regime to construct DTM.INT
-                strfmt = '(/4X,"Program pdtm v4.0: Init - Forming DTM.INT",/4X,"Cutoff parameter :",E8.1, &
+                strfmt = '(/4X,"Program pdtm v4.1: Init - Forming DTM.INT",/4X,"Cutoff parameter :",E8.1, &
                     /4X,"Full RES file - ",A3,/4X,"DM0.RES file - ",A3, &
                     /4X,"Do you want DM (1) OR TM (2) OR FORM DTM.INT (3)? ",I1)'
                 Call OpenFS('DTM.RES',0,11,1)

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -81,7 +81,7 @@ Program pdtm
         End If
         Close(11)
         Call stopTimer(start_time, timeStr)
-        write(*,'(2X,A)'), 'TIMING >>> Total computation time of dtm was '// trim(timeStr)
+        write(*,'(2X,A)') 'TIMING >>> Total computation time of dtm was '// trim(timeStr)
     End If
     Call MPI_Finalize(mpierr)
 
@@ -299,7 +299,7 @@ Contains
         equals_in_str = .true.
         Do While (equals_in_str)
             Read(99, '(A)', iostat=err_stat) line
-            If (index(string=line, substring="=") == 0 .or. err_stat) Then
+            If (index(string=line, substring="=") == 0 .or. err_stat /= 0) Then
                 equals_in_str = .false.
             Else
                 index_equals = index(string=line, substring="=")
@@ -407,7 +407,8 @@ Contains
         Return
     End Subroutine Input
 
-    Subroutine Init   
+    Subroutine Init
+        Use utils, Only : DetermineRecordLength
         ! This subroutine reads the head of the file CONF.DAT
         Implicit None
 
@@ -418,7 +419,7 @@ Contains
         Real(dp), Dimension(4*IP6):: PQ
         Character(Len=1) :: let(6)
         Character(Len=512) :: strfmt
-        logical :: longbasis
+        logical :: longbasis, success
         Integer, Dimension(4*IPs) :: IQN
         Real(dp), Dimension(IPs)  :: Qq1
         equivalence (IQN(1),PQ(21)),(Qq1(1),PQ(2*IPs+21))
@@ -430,7 +431,13 @@ Contains
         Cl=DPcl
         Mj=2*dabs(Jm)+0.01d0
 
-        Open (12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr,err=700)
+        Call DetermineRecordLength(Mrec, success)
+        If (.not. success) Then
+            Write(*,*) 'ERROR: record length could not be determined'
+            Stop
+        End If
+
+        Open (12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec,err=700)
         Call ReadF(12,1,P,Q,2)
         Call ReadF(12,3,P1,Q1,2)
         Z1  =PQ(1)
@@ -785,7 +792,7 @@ Contains
         Call calcNint
         dn=0.d0
         If (Kl == 1) Write(11,'(4X,"===== RADIAL INTEGRALS =====")')
-        Open(unit=12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr)
+        Open(unit=12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec)
         If (.not. Allocated(Rnt)) Allocate(Rnt(Nint))
         If (.not. Allocated(Intg)) Allocate(Intg(Nint))
         Nint=0
@@ -1498,7 +1505,7 @@ Contains
                         i=i+1
                     Else
                         Read(97,'(A)')
-                        Read(97,'(A)')    
+                        Read(97,'(A)')
                     End If
                 End Do
                 i=1
@@ -1563,8 +1570,8 @@ Contains
             lf=0
             iab2=0
             l2=0
-            save_energies(n1) = e1
-            save_J(n1) = tj1
+            save_energies(l1) = e1
+            save_J(l1) = tj1
             Do n2=n21,n22
                 l2=l2+1
                 lf=lf+1
@@ -1951,7 +1958,8 @@ Contains
         wl = abs(1e7/delEcm)
         ! Print table for E1_L and E1_V
         If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X, &
+                        F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE1 /= 0.d0 .and. AE1V /= 0.d0) Then
                 If (e2 > e1) Then
@@ -1959,11 +1967,14 @@ Contains
                 Else
                     tr = (2.02613e18/((2*tj2+1)*(wl*10)**3))*AE1**2
                 End If
-                Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1, AE1V, -e1, -e2, -delEcm, wl, tr
+                Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1, AE1V, &
+                                    -e1, -e2, -delEcm, wl, tr
             End If
         ! Print table for E1_L
         Else If (Keys%E1_L == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE1 /= 0.d0) Then
                 If (e2 > e1) Then
@@ -1971,11 +1982,14 @@ Contains
                 Else
                     tr = (2.02613e18/((2*tj2+1)*(wl*10)**3))*AE1**2
                 End If
-                Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1, -e1, -e2, -delEcm, wl, tr
+                Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1, &
+                                    -e1, -e2, -delEcm, wl, tr
             End If
         ! Print table for E1_V
         Else If (Keys%E1_V == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E1 ||",1X,A,2X,A,">",2X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE1V /= 0.d0) Then
                 If (e2 > e1) Then
@@ -1983,12 +1997,15 @@ Contains
                 Else
                     tr = (2.02613e18/((2*tj2+1)*(wl*10)**3))*AE1V**2
                 End If
-                Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1V, -e1, -e2, -delEcm, wl, tr
+                Write(100,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE1V, &
+                                    -e1, -e2, -delEcm, wl, tr
             End If
         End If
         ! Print table for E2
         If (Keys%E2 == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E2 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E2 ||",1X,A,2X,A,">",2X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (AE2 /= 0.d0) Then
                 If (e2 > e1) Then
@@ -1996,20 +2013,24 @@ Contains
                 Else
                     tr = (1.11995e18/((2*tj2+1)*(wl*10)**5))*AE2**2
                 End If
-                If (n2 > n1) Write(101,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE2, -e1, -e2, -delEcm, wl, tr
+                If (n2 > n1) Write(101,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE2, -e1, -e2, -delEcm, wl, tr
             End If
         End If
         ! Print table for E3
         If (Keys%E3 == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E3 ||",1X,A,2X,A,">",2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| E3 ||",1X,A,2X,A,">",2X, &
+                        F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AE3 /= 0.d0) Then
-                Write(102,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE3, -e1, -e2, -delEcm, wl
+                Write(102,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AE3, -e1, -e2, -delEcm, wl
             End If
         End If
         ! Print table for M1
         If (Keys%M1 == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M1 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M1 ||",1X,A,2X,A,">",7X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2,2X,E14.4)'
 
             If (G /= 0.d0) Then
                 If (e2 > e1) Then
@@ -2017,55 +2038,72 @@ Contains
                 Else
                     tr = (2.69735e13/((2*tj2+1)*(wl*10)**3))*G**2
                 End If
-                If (n2 > n1) Write(103,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), G, -e1, -e2, -delEcm, wl, tr
+                If (n2 > n1) Write(103,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), G, -e1, -e2, -delEcm, wl, tr
             End If
         End If
         ! Print table for M2
         If (Keys%M2 == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M2 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M2 ||",1X,A,2X,A,">",7X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM2 /= 0.d0) Then
-                Write(104,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM2, -e1, -e2, -delEcm, wl
+                Write(104,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM2, -e1, -e2, -delEcm, wl
             End If
         End If
         ! Print table for M3
         If (Keys%M3 == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M3 ||",1X,A,2X,A,">",7X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| M3 ||",1X,A,2X,A,">",7X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM3 /= 0.d0) Then
-                If (n2 > n1) Write(105,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM3, -e1, -e2, -delEcm, wl
+                If (n2 > n1) Write(105,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM3, -e1, -e2, -delEcm, wl
             End If
         End If
         ! Print table for EDM
         If (Keys%EDM == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| EDM ||",1X,A,2X,A,">",3X,E12.5,3X,E12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| EDM ||",1X,A,2X,A,">",3X,E12.5,3X,E12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (EDM /= 0.d0 .or. EDM1 /= 0.d0) Then
-                Write(108,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), EDM, EDM1, -e1, -e2, -delEcm, wl
+                Write(108,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), EDM, EDM1, &
+                                    -e1, -e2, -delEcm, wl
             End If
         End If
         ! Print table for PNC
         If (Keys%PNC == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| PNC ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| PNC ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (PNC /= 0.d0 .or. PNC1 /= 0.d0) Then
-                Write(109,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), PNC, PNC1, -e1, -e2, -delEcm, wl
+                Write(109,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), PNC, PNC1, &
+                                    -e1, -e2, -delEcm, wl
             End If
         End If
         ! Print table for AM
         If (Keys%AM == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| AM ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| AM ||",1X,A,2X,A,">",2X,F12.5,2X,F12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (AM /= 0.d0 .or. AM1 /= 0.d0) Then
-                Write(110,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM, AM1, -e1, -e2, -delEcm, wl
+                Write(110,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), AM, AM1, &
+                                    -e1, -e2, -delEcm, wl
             End If
         End If
         ! Print table for MQM
         If (Keys%MQM == 1) Then
-            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| MQM ||",1X,A,2X,A,">",3X,E12.5,9X,E12.5,2X,F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
+            strfmt = '(I3," -> ",I3,":",2X,"<",A,2X,A,1X,"|| MQM ||",1X,A,2X,A,">",3X,E12.5,9X,E12.5,2X, &
+                        F14.8,2X,F14.8,2X,F18.2,2X,F14.2)'
 
             If (QM /= 0.d0 .or. QM1 /= 0.d0) Then
-                Write(111,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), QM, QM1, -e1, -e2, -delEcm, wl
+                Write(111,strfmt) n1, n2, Trim(AdjustL(strc1(k1))) // strsp(1:nspaces1), AdjustR(strt1(k1)), &
+                                    Trim(AdjustL(strc2(k2))) // strsp(1:nspaces2), AdjustR(strt2(k2)), QM, QM1, &
+                                    -e1, -e2, -delEcm, wl
             End If
         End If
         Write(6, '(A)') ' '
@@ -2101,21 +2139,45 @@ Contains
         If (existStr) Then
             ! TM headers
             If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
-                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_L||J2>  <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // &
+                                    'trm2>   <J1||E1_L||J2>  <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1) &
+                                            WL (nm)   Tr. Rate (1/s)'
             Else If (Keys%E1_L == 1) Then
-                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // &
+                                    'trm2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm) &
+                                      Tr. Rate (1/s)'
             Else If (Keys%E1_V == 1) Then
-                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // 'trm2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+                Write(100,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E1 || conf2' // strsp(1:nspaces02) // &
+                                    'trm2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm) &
+                                      Tr. Rate (1/s)'
             End If
-            If (Keys%E2 == 1) Write(101,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E2 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||E2||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-            If (Keys%E3 == 1) Write(102,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E3 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||E3||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%M1 == 1) Write(103,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M1 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M1||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
-            If (Keys%M2 == 1) Write(104,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M2 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M2||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%M3 == 1) Write(105,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M3 || conf2' // strsp(1:nspaces02) // 'trm2>    <J1||M3||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%EDM == 1) Write(108,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || EDM || conf2' // strsp(1:nspaces02) // 'trm2>     EDM (a.u.)  EDM (Hz/e/cm)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%PNC == 1) Write(109,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || PNC || conf2' // strsp(1:nspaces02) // 'trm2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%AM == 1) Write(110,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || AM || conf2' // strsp(1:nspaces02) // 'trm2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%MQM == 1) Write(111,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 |  MQM | conf2' // strsp(1:nspaces02) // 'trm2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%E2 == 1) Write(101,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E2 || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>    <J1||E2||J2>       E1 (a.u.)       E2 (a.u.) &
+                                                     E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            If (Keys%E3 == 1) Write(102,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || E3 || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>    <J1||E3||J2>       E1 (a.u.)       E2 (a.u.) &
+                                                     E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M1 == 1) Write(103,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M1 || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>    <J1||M1||J2> (μ_0)      E1 (a.u.)       E2 (a.u.) &
+                                                     E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
+            If (Keys%M2 == 1) Write(104,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M2 || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>    <J1||M2||J2> (μ_0)      E1 (a.u.)       E2 (a.u.) &
+                                                     E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M3 == 1) Write(105,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || M3 || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>    <J1||M3||J2> (μ_0)      E1 (a.u.)       E2 (a.u.) &
+                                                     E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%EDM == 1) Write(108,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || EDM || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>     EDM (a.u.)  EDM (Hz/e/cm)       E1 (a.u.) &
+                                                      E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%PNC == 1) Write(109,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || PNC || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.) &
+                                                      E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%AM == 1) Write(110,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 || AM || conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>      AM (a.u)       AM (Hz)       E1 (a.u.)  &
+                                                     E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%MQM == 1) Write(111,'(A)') 'N1  ->  N2:  <conf1' // strsp(1:nspaces01) // 'trm1 |  MQM | conf2' // &
+                                                strsp(1:nspaces02) // 'trm2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.) &
+                                                      E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
 
             ! DM headers
             If (Keys%GF == 1) Write(112,'(A)') ' n   conf' // strsp(1:nspaces1) // 'term     gfactor      E_n (a.u.)'
@@ -2125,21 +2187,42 @@ Contains
         Else
             ! TM headers
             If (Keys%E1_L == 1 .and. Keys%E1_V == 1) Then
-                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>  <J1||E1_L||J2>  <J1||E1_V||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>  <J1||E1_L||J2>  <J1||E1_V||J2>       E1 (a.u.) &
+                                      E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
             Else If (Keys%E1_L == 1) Then
-                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_L||J2>      E1 (a.u.)       E2 (a.u.) &
+                                     E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
             Else If (Keys%E1_V == 1) Then
-                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+                Write(100,'(A)') 'N1  ->  N2:  < J1      M1 || E1 ||  J2      M2>   <J1||E1_V||J2>      E1 (a.u.)       E2 (a.u.) &
+                                     E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
             End If
-            If (Keys%E2 == 1) Write(101,'(A)') 'N1  ->  N2:  < J1      M1 || E2 ||  J2      M2>    <J1||E2||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
-            If (Keys%E3 == 1) Write(102,'(A)') 'N1  ->  N2:  < J1      M1 || E3 ||  J2      M2>    <J1||E3||J2>       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%M1 == 1) Write(103,'(A)') 'N1  ->  N2:  < J1      M1 || M1 ||  J2      M2>    <J1||M1||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
-            If (Keys%M2 == 1) Write(104,'(A)') 'N1  ->  N2:  < J1      M1 || M2 ||  J2      M2>    <J1||M2||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%M3 == 1) Write(105,'(A)') 'N1  ->  N2:  < J1      M1 || M3 ||  J2      M2>    <J1||M3||J2> (μ_0)      E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%EDM == 1) Write(108,'(A)') 'N1  ->  N2:  < J1      M1 || EDM ||  J2      M2>     EDM (a.u.)  EDM (Hz/e/cm)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%PNC == 1) Write(109,'(A)') 'N1  ->  N2:  < J1      M1 || PNC ||  J2      M2>    PNC (a.u.)      PNC (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%AM == 1) Write(110,'(A)') 'N1  ->  N2:  < J1      M1 || AM ||  J2      M2>      AM (a.u)       AM (Hz)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
-            If (Keys%MQM == 1) Write(111,'(A)') 'N1  ->  N2:  < J1      M1 || MQM ||  J2      M2>     MQM (a.u.)     MQM (Hz/e/cm**2)       E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%E2 == 1) &
+                Write(101,'(A)') 'N1  ->  N2:  < J1      M1 || E2 ||  J2      M2>    <J1||E2||J2>       E1 (a.u.) &
+                                                  E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)   Tr. Rate (1/s)'
+            If (Keys%E3 == 1) &
+                Write(102,'(A)') 'N1  ->  N2:  < J1      M1 || E3 ||  J2      M2>    <J1||E3||J2>       E1 (a.u.) &
+                                                  E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M1 == 1) &
+                Write(103,'(A)') 'N1  ->  N2:  < J1      M1 || M1 ||  J2      M2>    <J1||M1||J2> (μ_0)      E1 (a.u.) &
+                                                  E2 (a.u.)      E2-E1 (cm**-1)         WL (nm)     Tr. Rate (s)'
+            If (Keys%M2 == 1) &
+                Write(104,'(A)') 'N1  ->  N2:  < J1      M1 || M2 ||  J2      M2>    <J1||M2||J2> (μ_0)      E1 (a.u.) &
+                                                  E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%M3 == 1) &
+                Write(105,'(A)') 'N1  ->  N2:  < J1      M1 || M3 ||  J2      M2>    <J1||M3||J2> (μ_0)      E1 (a.u.) &
+                                                  E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%EDM == 1) &
+                Write(108,'(A)') 'N1  ->  N2:  < J1      M1 || EDM ||  J2      M2>     EDM (a.u.)  EDM (Hz/e/cm) &
+                                                  E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%PNC == 1) &
+                Write(109,'(A)') 'N1  ->  N2:  < J1      M1 || PNC ||  J2      M2>    PNC (a.u.)      PNC (Hz) &
+                                                  E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%AM == 1) &
+                Write(110,'(A)') 'N1  ->  N2:  < J1      M1 || AM ||  J2      M2>      AM (a.u)       AM (Hz) &
+                                                  E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
+            If (Keys%MQM == 1) &
+                Write(111,'(A)') 'N1  ->  N2:  < J1      M1 || MQM ||  J2      M2>     MQM (a.u.)     MQM (Hz/e/cm**2) &
+                                                  E1 (a.u.)       E2 (a.u.)      E2-E1 (cm**-1)           WL (nm)'
             ! DM headers
             If (Keys%GF == 1) Write(112,'(A)') ' n  J1       M1      gfactor      E_n (a.u.)'
             If (Keys%gQED == 1) Write(113,'(A)') ' n  J1       M1      gQED      E_n (a.u.)'
@@ -2336,7 +2419,7 @@ Contains
         strsp = ''
         nspaces1 = 0
 
-        If (existStr == .false.) Then
+        If (.not. existStr) Then
             Write(strc1(k1),'(F3.1)') tj
             Write(strt1(k1),'(F3.1)') tm
         End If

--- a/src/pol.f90
+++ b/src/pol.f90
@@ -40,7 +40,7 @@ Program pol
     !         General convention: GLOBAL VARIABLES     |||
     !              ARE CAPITALISED                     |||
     ! ||||||||||||||||||||||||||||||||||||||||||||||||||||
-    Use params, ipmr1 => IPmr, IP1conf => IP1
+    Use params, IP1conf => IP1
     Use determinants, Only : Dinit, Jterm
     Use str_fmt, Only : startTimer, stopTimer
 
@@ -171,7 +171,7 @@ Program pol
     Close(unit=11) ! Close POL.RES
     Close(unit=99) ! Close POL_E1.RES
     Call stopTimer(start_time, timeStr)
-    Write(*,'(2X,A)'), 'TIMING >>> Total computation time of pol was '// trim(timeStr)
+    Write(*,'(2X,A)') 'TIMING >>> Total computation time of pol was '// trim(timeStr)
     
 Contains
 
@@ -286,7 +286,7 @@ Contains
         equals_in_str = .true.
         Do While (equals_in_str)
             Read(88, '(A)', iostat=err_stat) line
-            If (index(string=line, substring="=") == 0 .or. err_stat) Then
+            If (index(string=line, substring="=") == 0 .or. err_stat /= 0) Then
                 equals_in_str = .false.
             Else
                 index_equals = index(string=line, substring="=")
@@ -360,7 +360,8 @@ Contains
         If (nrange > 0) Then
             Write(*,'(I2,A)') nrange, ' wavelength intervals with step size found:'
             Do i=1,nrange
-                Write(*,'(A,F11.3,A,F11.3,A,F11.4,A)')' lambda=',xlamb1s(i),' nm to ',xlamb2s(i),' nm in steps of ',xlambsteps(i), ' nm'
+                Write(*,'(A,F11.3,A,F11.3,A,F11.4,A)')' lambda=',xlamb1s(i),' nm to ',xlamb2s(i), &
+                                                        ' nm in steps of ',xlambsteps(i), ' nm'
             End Do
         Else
             Write(*,'(A)') 'ERROR: no wavelengths were specified'
@@ -864,7 +865,7 @@ Contains
         If (.not. Allocated(Hamil%t)) Allocate(Hamil%t(NumH))
         cnt=0
         Do i8=1,NumH
-            Read(15), Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
+            Read(15) Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
             if (Hamil%n(i8) == Nd + 1) then
                 NumH=cnt
                 print*,'For Nd=',Nd,', NumH=', NumH
@@ -1003,7 +1004,7 @@ Contains
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
         
         strfmt = '(3X," NumH =",I10,";  Hmin =",F12.6/)'
         Write(*,strfmt) NumH,Hmin
@@ -1036,14 +1037,14 @@ Contains
         Call system_clock(end2)
         ttime2=Real((end2-start2)/clock_rate)
         Call FormattedTime(ttime2, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Zspsv in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Zspsv in '// trim(timeStr)// '.'
 
         X1= 0.d0
         X1(1:Ntr)= Real(XX1(1:Ntr), kind=dp)
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: decomp in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: decomp in '// trim(timeStr)// '.'
         
         If (sign == 1) Then
             Open(unit=16,file='POL_p.XIJ',status='UNKNOWN',form='UNFORMATTED')

--- a/src/pol.f90
+++ b/src/pol.f90
@@ -390,7 +390,7 @@ Contains
 
         Call ReadPolIn
 
-        strfmt = '(1X,70("-"),/1X,"Program pol v1.0")'
+        strfmt = '(1X,70("-"),/1X,"Program pol v1.1")'
         Write( 6,strfmt) 
         Write(11,strfmt) 
 

--- a/src/sort.f90
+++ b/src/sort.f90
@@ -16,7 +16,7 @@ program sort
 
     ! End program timer
     call stopTimer(start_time, time_str)
-    write(*,'(2X,A)'), 'TIMING >>> Total computation time of sort was '// trim(time_str)
+    write(*,'(2X,A)') 'TIMING >>> Total computation time of sort was '// trim(time_str)
 
 contains
 
@@ -57,7 +57,7 @@ contains
     
         ! Sort matrix elements
         call startTimer(start_time2)
-        call quicksort_matrix(mat%indices1, mat%indices2, mat%values, 1, num_total_elements)
+        call quicksort_matrix(mat%indices1, mat%indices2, mat%values, 1_int64, num_total_elements)
         call stopTimer(start_time2, time_str2)
         print*, trim(adjustl(filename)) // ' sorted in ' // trim(adjustl(time_str2))
         

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -1,31 +1,74 @@
-module utils
+Module utils
     ! This module contains general utility functions and subroutines for the pCI software package
 
-    implicit none
+    Implicit None
 
-    private
+    Private
 
-    public :: CountSubstr
+    Public :: CountSubstr, DetermineRecordLength
 
-contains
+Contains
 
-    function CountSubstr(str, substr) result(count)
+    Function CountSubstr(str, substr) Result(count)
         ! This function counts the number of occurences of a substring in a string
-        implicit none
+        Implicit None
 
-        integer :: i, position, count
-        character(len=*), intent(in) :: str
-        character(len=*), intent(in) :: substr
+        Integer :: i, position, count
+        Character(Len=*), Intent(In) :: str
+        Character(Len=*), Intent(In) :: substr
 
         count = 0
         i = 1
-        do 
+        Do 
             position = index(str(i:), substr)
-            if (position == 0) return
+            If (position == 0) Return
             count = count + 1
             i = i + position + len(substr) - 1
-        end do
+        End Do
 
-    end function CountSubstr
+    End Function CountSubstr
 
-end module utils
+    Subroutine DetermineRecordLength(lrec, success)
+        ! Determines the minimum usable record length for direct access files 
+        Integer, intent(Out) :: lrec
+        Logical, intent(Out) :: success
+
+        Integer :: irecl, err_stat
+        Character(Len=8) :: test_data, read_data
+
+        test_data = 'abcdefgh'
+        irecl = 1
+        success = .false.
+
+        Do
+            ! Open a file to test writing and reading test_data with increasing record length
+            Open(unit=10, file='test.tmp', status='UNKNOWN', access='DIRECT', recl=irecl, iostat=err_stat)
+            If (err_stat /= 0) then
+                Exit
+            End If
+
+            ! Try writing test_data
+            Write(10, rec=1, iostat=err_stat) test_data
+            If (err_stat /= 0) Then
+                Close(unit=10, status='DELETE')
+                irecl = irecl + 1
+                Cycle
+            End If
+
+            ! Try reading read_data
+            Read(10, rec=1, iostat=err_stat) read_data
+            Close(unit=10, status='DELETE')
+            If (err_stat == 0 .and. read_data == test_data) Then
+                success = .true.
+                lrec = irecl
+                Exit
+            End If
+        End Do
+    
+        If (.not. success) Then
+            lrec = -1
+        End If
+
+    End Subroutine DetermineRecordLength
+
+End Module utils

--- a/src/wigner.f90
+++ b/src/wigner.f90
@@ -1,6 +1,6 @@
 Module wigner
 
-    Use params 
+    Use, Intrinsic :: iso_fortran_env, Only : dp => real64
 
     Implicit None
 


### PR DESCRIPTION
- refactored main programs for gfortran compatibility
- check_matrices.f90 - small new program check_matrices to check for errors in CONFp.HIJ and CONFp.JJJ
- updated matrix_io.f90 to use mpi_f08
- pconf.f90 -> pconf.F90, use preprocessing directives to compile ScaLAPACK routines
- pconf - fixed allocation of array E for LAPACK subroutines
- removed IPmr parameter from params.f90 and refactored IPmr-associated arrays