### PR TITLE
v1.1.0 gfortran compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0] - 2024-12-13
+## [1.1.0] - 2024-12-16
 - refactored main programs for gfortran compatibility
 - check_matrices.f90 - small new program check_matrices to check for errors in CONFp.HIJ and CONFp.JJJ
 - updated matrix_io.f90 to use mpi_f08
 - pconf.f90 -> pconf.F90, use preprocessing directives to compile ScaLAPACK routines
 - pconf - fixed allocation of array E for LAPACK subroutines
 - removed IPmr parameter from params.f90 and refactored IPmr-associated arrays
+- removed IPmr parameter from all-order package and refactored IPmr-associated arrays using rec_unit module
 - pconf - refactored KXIJ and KWeights into optional inputs
 - removed IP1 parameter from params.f90 and refactored IP1-associated arrays from main programs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pconf.f90 -> pconf.F90, use preprocessing directives to compile ScaLAPACK routines
 - pconf - fixed allocation of array E for LAPACK subroutines
 - removed IPmr parameter from params.f90 and refactored IPmr-associated arrays
+- pconf - refactored KXIJ and KWeights into optional inputs
 
 ## [1.0.7] - 2024-11-17
 - refactored IP1 parameter out of pdtm.f90 and removed IP1 array size warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2024-12-13
+- refactored main programs for gfortran compatibility
+- check_matrices.f90 - small new program check_matrices to check for errors in CONFp.HIJ and CONFp.JJJ
+- updated matrix_io.f90 to use mpi_f08
+- pconf.f90 -> pconf.F90, use preprocessing directives to compile ScaLAPACK routines
+- pconf - fixed allocation of array E for LAPACK subroutines
+- removed IPmr parameter from params.f90 and refactored IPmr-associated arrays
+
 ## [1.0.7] - 2024-11-17
 - refactored IP1 parameter out of pdtm.f90 and removed IP1 array size warnings
 - fixed formatting of Operator.RES files produced by pdtm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pconf - fixed allocation of array E for LAPACK subroutines
 - removed IPmr parameter from params.f90 and refactored IPmr-associated arrays
 - pconf - refactored KXIJ and KWeights into optional inputs
+- removed IP1 parameter from params.f90 and refactored IP1-associated arrays from main programs
 
 ## [1.0.7] - 2024-11-17
 - refactored IP1 parameter out of pdtm.f90 and removed IP1 array size warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - removed IPmr parameter from all-order package and refactored IPmr-associated arrays using rec_unit module
 - pconf - refactored KXIJ and KWeights into optional inputs
 - removed IP1 parameter from params.f90 and refactored IP1-associated arrays from main programs
+- add - increased allowed number of shells per configuration to up to 24
 
 ## [1.0.7] - 2024-11-17
 - refactored IP1 parameter out of pdtm.f90 and removed IP1 array size warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,21 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 
 project(pci 
-        VERSION 1.0.7
+        VERSION 1.1.0
         DESCRIPTION "pCI software package"
         LANGUAGES Fortran)
 include(GNUInstallDirs)
 
-# Need Intel Fortran compiler
-if (NOT ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" AND NOT ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM")
-    message(FATAL_ERROR "Intel Fortran compiler (ifort or ifx) not found. Please ensure FC is set to 'ifort' or 'ifx'.")
-else()
+# Need a Fortran compiler
+if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM")
     message(STATUS "Intel Fortran compiler found: ${CMAKE_Fortran_COMPILER}")
     message(STATUS "Intel Fortran compiler: ${CMAKE_Fortran_COMPILER_ID}")
+elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
+    message(STATUS "GNU Fortran compiler found: ${CMAKE_Fortran_COMPILER}")
+    message(STATUS "GNU Fortran compiler: ${CMAKE_Fortran_COMPILER_ID}")
+    message(WARNING "Optional programs for QED and all-order are not compilable with gfortran")
+else()
+    message(FATAL_ERROR "Intel or GNU Fortran compiler was not detected.")
 endif()
 
 # Need MPI
@@ -27,6 +31,43 @@ else()
     message(FATAL_ERROR "OpenMPI not detected. Please ensure OpenMPI is installed and loaded, and that mpifort points to the OpenMPI version.")
 endif()
 
+# Need BLAS and LAPACK
+# Find MKL
+find_package(MKL QUIET)
+if (MKL_FOUND)
+    message(STATUS "MKL libary detected: ${MKL_LIBRARIES}")
+else()
+    # If find_package can't find MKL, manually check for MKL
+    set(MKL_ROOT $ENV{MKLROOT})
+    
+    if (MKL_ROOT)
+        set(MKL_INCLUDE_DIR "${MKL_ROOT}/include")
+        set(MKL_LIB_DIR "${MKL_ROOT}/lib/intel64")
+        message(STATUS "MKL library detected: ${MKL_LIB_DIR}")
+    else()
+        message(STATUS "MKL library not detected. Falling back to BLAS and LAPACK.")
+
+        # Find BLAS and LAPACK
+        find_package(BLAS REQUIRED)
+        find_package(LAPACK REQUIRED)
+        if (BLAS_FOUND AND LAPACK_FOUND)
+            message(STATUS "BLAS library detected: ${BLAS_LIBRARIES}")
+            message(STATUS "LAPACK library detected: ${LAPACK_LIBRARIES}")
+        else()
+            message(FATAL_ERROR "BLAS and LAPACK not detected. Please ensure BLAS and LAPACK are installed.")
+        endif()
+
+        # Find ScaLAPACK
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+        find_package(ScaLAPACK QUIET)
+        if (ScaLAPACK_FOUND)
+            message(STATUS "ScaLAPACK detected: ${ScaLAPACK_LIBRARIES}")
+        else()
+            message(FATAL_ERROR "ScaLAPACK not detected.")
+        endif()
+    endif()
+endif()
+
 # Add default Intel compile/link flags:
 if (${CMAKE_Fortran_COMPILER} MATCHES "ifort")
     set(MKL_PARALLEL_FLAGS -qopenmp -mkl=parallel)
@@ -38,6 +79,9 @@ elseif (${CMAKE_Fortran_COMPILER} MATCHES "ifx")
     set(MKL_PARALLEL_LINK_FLAGS -qopenmp -qmkl=parallel -lmkl_scalapack_lp64 -lmkl_blacs_openmpi_lp64)
     add_compile_options(-qopenmp -qmkl=sequential)
     add_link_options(-qopenmp -qmkl=sequential -lmkl_scalapack_lp64 -lmkl_blacs_openmpi_lp64)
+elseif (${CMAKE_Fortran_COMPILER} MATCHES "gfortran")
+    add_compile_options(-fopenmp -lscalapack -lblas -llapack)
+    add_link_options(-fopenmp -lscalapack -lblas -llapack)
 endif()
 # The FindMPI returns linker flags as a space-delimited string, but target_link_options() needs a list:
 string(REGEX REPLACE "[ \t\r\n]" ";" MPI_Fortran_LINK_FLAGS "${MPI_Fortran_LINK_FLAGS}")

--- a/cmake/modules/FindScaLAPACK.cmake
+++ b/cmake/modules/FindScaLAPACK.cmake
@@ -1,0 +1,41 @@
+# CMake "find module" for ScaLAPACK. Even though reference ScaLAPACK
+# provides a CMake config file, the Intel MKL version of ScaLAPACK
+# does not. This CMake find module can be bypassed in favor of
+# detecting the reference ScaLAPACK find module via setting
+# CMAKE_FIND_PACKAGE_PREFER_CONFIG to TRUE.
+
+# General strategy:
+#
+# 1) Easiest: check to see if reference ScaLAPACK installed.
+#
+# 2) Check to see if PBLAS is needed. (If it is, fail for now, then
+# implement a FindPBLAS.cmake later on.)
+#
+# 3) Check to see if BLACS is needed. (If it is, fail for now, then
+# implement a FindBLACS.cmake later on.)
+#
+# 4) Probably need to implement the basics of a FindMKL.cmake package.
+#
+
+# Search hardcoded paths as follows:
+# - /usr/lib64 and /usr/lib for system-wide Linux/BSD installation via system
+#   package manager
+# - /usr/local/lib64 and /usr/local/lib for system-wide Linux/BSD installation
+#    outside of system package manager; includes Homebrew
+# - /opt/local for MacPorts installation
+# - /sw/lib or /opt/sw/lib for Fink installation
+find_library(ScaLAPACK_LIBRARY
+  NAMES scalapack scalapack-mpi scalapack-mpich scalapack-mpich2 scalapack-openmpi
+  PATHS /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib
+  /opt/local/lib /opt/sw/lib /sw/lib
+  ENV LD_LIBRARY_PATH
+  ENV DYLD_FALLBACK_LIBRARY_PATH
+  ENV DYLD_LIBRARY_PATH
+  ENV SCALAPACKDIR
+  ENV BLACSDIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ScaLAPACK
+  REQUIRED_VARS ScaLAPACK_LIBRARY
+  )
+set(ScaLAPACK_LIBRARIES ${ScaLAPACK_LIBRARY})

--- a/lib/all-order/bas_wj.for
+++ b/lib/all-order/bas_wj.for
@@ -51,6 +51,7 @@ C     - - - - - - - - - - - - - - - - - - - - - - - - -
 C     =================================================
       include "readf.inc"
       include "rintms.f"
+      include "rec_unit.inc"
 C     =================================================
       subroutine Input
       implicit real*8 (a-h,o-z)
@@ -499,11 +500,13 @@ C     =================================================
        common /g0/g0(IPx6,IPxo,IPpw)/f0/f0(IPx6,IPxo,IPpw)
      >        /En0/En0(2*IPxo,IPpw)/Pn/Pn(IPx6)/Qn/Qn(IPx6)
      >        /Norb/Norb(IPxo,IPpw)
-
+       common /ipmr/ipmr
        dimension P(IP6),Q(IP6),P1(IP6),Q1(IP6)
 
        character*1 let, FNAME1*12
+
 C     - - - - - - - - - - - - - - - - - - - - - - - - -
+        call recunit
         open(12,file=FNAME1,access='DIRECT',
      >       status='UNKNOWN',recl=2*IP6*IPmr)
         close(12,status='DELETE')

--- a/lib/all-order/bas_x.for
+++ b/lib/all-order/bas_x.for
@@ -23,10 +23,12 @@ C     - - - - - - - - - - - - - - - - - - - - - - - - -
      >        /C/C(IP6)/R/R(IP6)/V/V(IP6)
      >        /P/P(IP6)/Q/Q(IP6)/CP/CP(IP6)/CQ/CQ(IP6)
        common /kout/kout/small/small/let/let(6)
+       common /ipmr/ipmr
        character*1 let,ch4,FNAME*12
 C     - - - - - - - - - - - - - - - - - - - - - - - - -
         MaxT=9           !### length of expansion at the origin
         kout=1           !### output details
+        call recunit
         irec=2*IP6*IPmr  !### record length in DAT files
         let(1)='s'
         let(2)='p'
@@ -45,6 +47,7 @@ c        open(unit=11,file='BAS_X.RES',status='UNKNOWN')
 C     =================================================
       include "readf.inc"
       include "rintms.f"
+      include "rec_unit.inc"
 C     =================================================
       subroutine Init
       implicit real*8 (a-h,o-z)
@@ -56,6 +59,7 @@ C     =================================================
      1        /Z/Z/Cl/Cl/H/H/Rnuc/Rnuc
        common /Kk/Kk(IPs)/Jj/Jj(IPs)/Nn/Nn(IPs)/Ll/Ll(IPs)/Qq/Qq(IPs)
      >        /R/R(IP6)/V/V(IP6)
+       common /ipmr/ipmr
        dimension P(IP6),Q(IP6),P1(IP6),Q1(IP6),PQ(4*IP6)
        logical longbasis
        dimension IQN(4*IPs),Qq1(IPs)
@@ -288,6 +292,7 @@ C     =================================================
        common /ii/ii/iix/iix/Kt/Kt/H/H/Rnuc/Rnuc
        common /P/P(IP6)/Q/Q(IP6)/Pn/Pn(IPx6)/Qn/Qn(IPx6)
      >        /En/En(2*IPxo)/Rn/Rn(IPx6)/Vn/Vn(IPx6)/C/C(IPx6)
+       common /ipmr/ipmr
        dimension g(IPx6,IPxo),f(IPx6,IPxo)
 C     - - - - - - - - - - - - - - - - - - - - - - - - -
        write(*,*) ' Rewriting orbitals on new grid'

--- a/lib/all-order/include/basx.par
+++ b/lib/all-order/include/basx.par
@@ -6,6 +6,5 @@ c #################################################################
      >           IPxo =     40,  !### number of orbitals in PW =nx
      >           IPkx =     15,  !### defines array tx in hfspl.1 =kx
      >           IPpw =     17)  !### max num of partial waves
-       PARAMETER(IPmr  =     1)  !###  =4 if word=1B (Pentium)
-                                 !###  =1 if word=4B (Alpha-processor)
+     
 !!!! Note that these parameters should agree with nhf,nx, &kx in allcore.par

--- a/lib/all-order/include/rec_unit.inc
+++ b/lib/all-order/include/rec_unit.inc
@@ -1,0 +1,39 @@
+c       =================================================
+        subroutine recunit
+c       - - - - - - - - - - - - - - - - - - - - - - - - -
+        implicit real*8 (a-h,o-z)
+c       - - - - - - - - - - - - - - - - - - - - - - - - -
+        character*8 d1,t1,d2,t2
+        common /ipmr/ipmr
+c       - - - - - - - - - - - - - - - - - - - - - - - - -
+c       Determination of the record unit.
+c       - - - - - - - - - - - - - - - - - - - - - - - - -
+        t1='abcdefgh'
+        d1='        '
+        t2='hgfedcba'
+        d2='        '
+        lrec=0
+        iflag=1
+200     lrec=lrec+1
+        if (lrec.gt.8) then
+          write(*,*)  'lrec > 8'
+          stop
+        end if
+        open(unit=13,file='test.tmp',status='unknown',
+     >       access='direct',recl=lrec)
+        write(13,rec=1,err=210) t1
+        write(13,rec=2,err=210) t2
+        read(13,rec=1,err=210) d1
+        read(13,rec=2,err=210) d2
+        if (d1.ne.t1) goto 210
+        if (d2.ne.t2) goto 210
+        iflag=0
+210     close(unit=13,status='delete')
+        if (iflag.ne.0) goto 200
+        nbytes=8/lrec
+        ipmr=8/nbytes
+C        write( *,5) nbytes
+C5       format(/2x,'Record unit =',i2,' byte(s)')
+c       - - - - - - - - - - - - - - - - - - - - - - - - -
+        return
+        end

--- a/lib/all-order/include/second.par
+++ b/lib/all-order/include/second.par
@@ -9,7 +9,6 @@
       PARAMETER (NXX1=30,NK1=15,IPX=440,NSIG=423000000)
 *     parameters for the all-order merge
       PARAMETER (NZ=100,NVWH=140000)
-      PARAMETER (IPmr=1)
 ***********************************************************************
 *     LINE 1                                                          *
 *                                                                     *

--- a/lib/all-order/second-ci.f
+++ b/lib/all-order/second-ci.f
@@ -518,6 +518,7 @@ C     =================================================
       include "hfd.par"  !### check directory for hfd.par!
       include "second.par"
        common /bassinp/ nor(nsorb),kor(nsorb),norb
+       common /ipmr/ipmr
        dimension P(IP6),Q(IP6),P1(IP6),Q1(IP6),PQ(4*IP6)
        logical longbasis
        dimension IQN(4000) ! dimension should be .GE. 4*IPs, IPs from conf.par
@@ -527,6 +528,7 @@ C     =================================================
 C     - - - - - - - - - - - - - - - - - - - - - - - - -
 c small number:
         c1=0.01d0
+        call recunit
 C     - - - - - - - - - - - - - - - - - - - - - - - - -
         open(12,file='HFD.DAT',access='DIRECT',
      >       status='OLD',recl=2*IP6*IPmr,err=700)
@@ -2373,3 +2375,4 @@ c     ========================================
       include "yfun.f"
       include "yint.f"
       include "inidat.f"
+      include "rec_unit.inc"

--- a/lib/include/rec_unit.inc
+++ b/lib/include/rec_unit.inc
@@ -31,7 +31,7 @@ c       - - - - - - - - - - - - - - - - - - - - - - - - -
 210     close(unit=13,status='delete')
         if (iflag.ne.0) goto 200
         nbytes=8/lrec
-        ipmr=4/nbytes
+        ipmr=8/nbytes
 C        write( *,5) nbytes
 C5       format(/2x,'Record unit =',i2,' byte(s)')
 c       - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/py-lib/basis.py
+++ b/py-lib/basis.py
@@ -475,16 +475,27 @@ def write_hfd_inp_ci(filename, system, num_electrons, Z, AM, kbrt, NL_base, J_ba
             if shell_fmt not in frozen_shells:
                 frozen_shells.append(shell_fmt)
                 frozen_found[shell_fmt] = False
-        
+
         # Write the HFD.INP to construct orbitals for this shell
         NS = len(NL)
-        NSO = len(core_shells)
+        NSO = count_orbitals_in_list(core_shells)
         write_hfd_inp('HFD'+str(index)+'.INP', system, NS, NSO, Z, AM, kbrt, NL, J, QQ, KP, NC, rnuc, K_is, C_is)
         
         index += 1
 
+def count_orbitals_in_list(shell_list):
+    # count number of orbitals in list of shells
+    num_orbitals = 0
+    for shell in shell_list:
+        if 'S' in shell or 's' in shell:
+            num_orbitals += 1
+        else:
+            num_orbitals += 2
+    
+    return num_orbitals
+
 def construct_vvorbs(core, valence, codename, nmax, lmax):
-# Construct list of valence and virtual orbitals
+    # Construct list of valence and virtual orbitals
     vorbs = []
     norbs = []
 

--- a/py-lib/gen_job_script.py
+++ b/py-lib/gen_job_script.py
@@ -21,7 +21,7 @@ def write_job_script(path, code, num_nodes, num_procs_per_node, exclusive, mem, 
     # Obtain list of partitions
     try:
         sinfo_output = run(['sinfo', '--format=%P'], capture_output=True, text=True, check=True)
-        partitions = set(sinfo_output.stdout.strip().splitlines())
+        partitions = set(line.rstrip('*') for line in sinfo_output.stdout.strip().splitlines())
         if partition in partitions:
             print('partition', partition, 'found on', cluster)
         else:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(hfd PUBLIC pci_common)
 ADD_EXECUTABLE(bass bass.f90)
 target_link_libraries(bass PUBLIC pci_common)
 
-ADD_EXECUTABLE(add params.f90 vaccumulator.f90 add.f90)
+ADD_EXECUTABLE(add params.f90 add.f90)
 target_link_libraries(add PUBLIC pci_common)
 
 ADD_EXECUTABLE(pbasc pbasc.f90)
@@ -24,7 +24,7 @@ target_include_directories(pbasc PUBLIC ${MPI_Fortran_INCLUDE_DIRS})
 target_link_options(pbasc PUBLIC ${MPI_Fortran_LINK_FLAGS})
 target_link_libraries(pbasc PUBLIC ${MPI_Fortran_LIBRARIES} pci_common)
 
-ADD_EXECUTABLE(pconf env_var.f90 matrix_io.f90 vaccumulator.f90 formj2.f90 davidson.f90 pconf.f90)
+ADD_EXECUTABLE(pconf env_var.f90 matrix_io.f90 vaccumulator.f90 formj2.f90 davidson.f90 pconf.F90)
 target_compile_definitions(pconf PUBLIC ${MPI_Fortran_COMPILE_DEFINITIONS})
 target_compile_options(pconf PUBLIC ${MPI_Fortran_COMPILE_OPTIONS})
 target_include_directories(pconf PUBLIC ${MPI_Fortran_INCLUDE_DIRS})
@@ -55,6 +55,9 @@ target_link_libraries(pdtm PUBLIC ${MPI_Fortran_LIBRARIES} pci_common)
 ADD_EXECUTABLE(sort str_fmt.f90 sort.f90)
 target_link_libraries(sort PUBLIC pci_common)
 
+ADD_EXECUTABLE(check_matrices check_matrices.f90)
+target_link_libraries(check_matrices PUBLIC pci_common)
+
 ADD_EXECUTABLE(ine ine.f90)
 target_link_options(ine PRIVATE ${MKL_PARALLEL_LINK_FLAGS})
 target_link_libraries(ine PRIVATE ${MKL_PARALLEL_LINK_FLAGS} pci_common)
@@ -70,4 +73,4 @@ target_include_directories(formy PUBLIC ${MPI_Fortran_INCLUDE_DIRS})
 target_link_options(formy PUBLIC ${MPI_Fortran_LINK_FLAGS})
 target_link_libraries(formy PUBLIC ${MPI_Fortran_LIBRARIES} pci_common)
 
-INSTALL(TARGETS hfd bass add pbasc pconf conf_lsj pdtm ine pol conf_pt sort formy DESTINATION ${CMAKE_INSTALL_BINDIR})
+INSTALL(TARGETS hfd bass add pbasc pconf conf_lsj pdtm ine pol conf_pt sort check_matrices formy DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/add.f90
+++ b/src/add.f90
@@ -172,7 +172,7 @@ Contains
 
         Deallocate(nyi, myi, nyk, myk)
 
-        max_num_shells = nsmc+2*Mult
+        max_num_shells = nsmc+2*Mult+1
         Allocate(Ac(growth_size, max_num_shells))
         Do ic=1,Ncor
             Do j=1,nsmc
@@ -383,13 +383,6 @@ Contains
                 End If
                 ir=ir*iv(i)
             End Do
-
-            ! Check if number of relativistic configurations exceeds ivv array limit
-            If (ir.GT.500) Then
-                write(*,*) ' number of relativistic configurations ',ir
-                write(*,*) ' in one NR configuration exceed array size 500'
-                stop
-            End If
 
             ivc(jk)=1
             Do i=jk-1,1,-1

--- a/src/add.f90
+++ b/src/add.f90
@@ -172,7 +172,7 @@ Contains
 
         Deallocate(nyi, myi, nyk, myk)
 
-        max_num_shells = nsmc+2*Mult+1
+        max_num_shells = nsmc*2
         Allocate(Ac(growth_size, max_num_shells))
         Do ic=1,Ncor
             Do j=1,nsmc
@@ -912,9 +912,18 @@ Contains
             if (NOz(ic).GT.6.AND.NOz(ic).LE.12) then
               write (11,65) ic1,(Ac(ic,j),j=1,6)
               write (11,55) (Ac(ic,j),j=7,NOz(ic))
+            else if (NOz(ic).GT.12.AND.NOz(ic).LE.18) then
+                write (11,65) ic1,(Ac(ic,j),j=1,6)
+                write (11,55) (Ac(ic,j),j=7,12)
+                write (11,55) (Ac(ic,j),j=13,NOz(ic))
+            else if (NOz(ic).GT.18.AND.NOz(ic).LE.24) then
+                write (11,65) ic1,(Ac(ic,j),j=1,6)
+                write (11,55) (Ac(ic,j),j=7,12)
+                write (11,55) (Ac(ic,j),j=13,18)
+                write (11,55) (Ac(ic,j),j=19,NOz(ic))
             else
               write (*,75) ic,NOz(ic)
- 75           format ("NOz(",I5,")=",I3," is greater than 12")
+ 75           format ("NOz(",I5,")=",I3," is greater than 24")
               Stop
             end if
           end if

--- a/src/add.f90
+++ b/src/add.f90
@@ -172,7 +172,7 @@ Contains
 
         Deallocate(nyi, myi, nyk, myk)
 
-        max_num_shells = nsmc*2
+        max_num_shells = (nsmc+Mult)*2
         Allocate(Ac(growth_size, max_num_shells))
         Do ic=1,Ncor
             Do j=1,nsmc

--- a/src/add.f90
+++ b/src/add.f90
@@ -12,7 +12,7 @@ Program add
     Real(dp), Allocatable, Dimension(:) :: V, Nqmin, Nqmax
 
     ! Print program header
-    strfmt = '(/4X,"PROGRAM add v3.0"/)'
+    strfmt = '(/4X,"PROGRAM add v3.1"/)'
     Write(6, strfmt)
 
     ! Read inputs from ADD.INP
@@ -652,7 +652,7 @@ Contains
         New=.FALSE.
   
         Do j=1,noz1                  !### check of the Pauli principle:
-            i1=sign(1.01,Ac1(j))     !#### nq.LE.(4*l+2)
+            i1=sign(1.01_dp,Ac1(j))     !#### nq.LE.(4*l+2)
             d=abs(Ac1(j))+1.E-6
             d=10*d
             nnj=d
@@ -665,7 +665,7 @@ Contains
         End Do
 
         Do j=1,noz1                  ! does this config.
-            i1=sign(1.01,Ac1(j))     !  belong to RAS?
+            i1=sign(1.01_dp,Ac1(j))     !  belong to RAS?
             d=abs(Ac1(j))+1.E-6
             d=10*d
             nnj=d

--- a/src/basc_variables.f90
+++ b/src/basc_variables.f90
@@ -2,7 +2,8 @@ Module basc_variables
 
     Use params
     Use conf_variables, Only : Ecore, Rint1, Iint1, IntOrd, Rint2, Iint2, Iint3, &
-                                R_is, I_is, In, Gnt, Nlx, num_gaunts_per_partial_wave, Ngint
+                                R_is, I_is, In, Gnt, Nlx, num_gaunts_per_partial_wave, Ngint, &
+                                type2_real
 
     Implicit None
 

--- a/src/basc_variables.f90
+++ b/src/basc_variables.f90
@@ -1,7 +1,8 @@
 Module basc_variables
 
-    Use params, ipmr1 => IPmr
-    Use conf_variables, Only : Ecore, Rint1, Iint1, IntOrd, Rint2, Iint2, Iint3, R_is, I_is, In, Gnt, Nlx, num_gaunts_per_partial_wave, Ngint
+    Use params
+    Use conf_variables, Only : Ecore, Rint1, Iint1, IntOrd, Rint2, Iint2, Iint3, &
+                                R_is, I_is, In, Gnt, Nlx, num_gaunts_per_partial_wave, Ngint
 
     Implicit None
 

--- a/src/bass.f90
+++ b/src/bass.f90
@@ -1,13 +1,14 @@
 Program bass
     Use basc_variables, Kbasparam => Kbas, Qqparam => Qq, letparam => let, Rint2param => Rint2
     Use readfff
+    Use utils, Only : DetermineRecordLength
     Implicit None
     
-    Integer :: irec, Nsint, Kdg, Ksg, Khf, Kkin, Ierr, Norb, Nsv, ni, iort, i, n,  &
+    Integer :: irec, Nsint, Kdg, Ksg, Khf, Kkin, Ierr, Norb, Nsv, ni, iort, i, n, &
                 nlst, nr, nmin, idg, ier_A, n11, n1, j1, n3, j3, n4, j4, n5, j5, l, ii3, Ns3
     Real(dp) :: Sf, Emin, Emax
 
-    Logical :: intrpl
+    Logical :: intrpl, success
     Integer, Dimension(IPs) :: Jj3, Nn3, Ll3
     Integer, Dimension(IPs) :: kw, numw, nb, jjw ! PW
     Integer, Allocatable, Dimension(:) :: Kbas
@@ -30,11 +31,15 @@ Program bass
     R3=0_dp
     V3=0_dp
 
-    call recunit
-    IPmr=1           ! word length in direct access files
+    Call DetermineRecordLength(Mrec, success)
+    If (.not. success) Then
+        Write(*,*) 'ERROR: record length could not be determined'
+        Stop
+    End If
+
     MaxT=9           !### length of expansion at the origin
     kout=1           !### output details
-    irec=2*IP6*IPmr  !### record length in DAT files
+    irec=2*IP6*Mrec  !### record length in DAT files
     small=1.d-8
     FNAME='BAS_A.DAT'
     Kt1=0            !### used as Kt for Breit integrals
@@ -233,41 +238,6 @@ Contains
         end do
     End Function N_orb
 
-    Subroutine recunit
-        ! Determination of the record unit.
-        Implicit None
-        
-        Integer :: lrec, iflag, ipmr, nbytes
-        Character(Len=8) :: d1,t1,d2,t2
-
-        t1='abcdefgh'
-        d1='        '
-        t2='hgfedcba'
-        d2='        '
-        lrec=0
-        iflag=1
-200     lrec=lrec+1
-        if (lrec.gt.8) then
-          write(*,*)  'lrec > 8'
-          stop
-        end if
-        open(unit=13,file='test.tmp',status='unknown',access='direct',recl=lrec)
-        write(13,rec=1,err=210) t1
-        write(13,rec=2,err=210) t2
-        read(13,rec=1,err=210) d1
-        read(13,rec=2,err=210) d2
-        if (d1.ne.t1) goto 210
-        if (d2.ne.t2) goto 210
-        iflag=0
-210     close(unit=13,status='delete')
-        if (iflag.ne.0) goto 200
-        nbytes=8/lrec
-        ipmr=4/nbytes
-
-        Return
-
-    End Subroutine recunit
-
     Subroutine Input
         Use conf_init, Only : inpstr
         Implicit None
@@ -278,7 +248,7 @@ Contains
 
         data str1,str2,str3 /'   DF','Brcnr','Breit','Br+Bt',' NO','YES','YES','E = V = 0','E=0, V_c ','E_hf, V_c'/
 
-        strfmt = '(/4X,"Program Bass v1.2")'
+        strfmt = '(/4X,"Program Bass v1.3")'
         write( *,strfmt)
         write(11,strfmt)
 
@@ -456,7 +426,7 @@ Contains
         Mj=2*dabs(Jm)+0.01d0
         Qw=0_dp
 
-        Open(12,file='HFD.DAT',access='DIRECT',status='OLD',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        Open(12,file='HFD.DAT',access='DIRECT',status='OLD',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             strfmt='(/2X,"file HFD.DAT is absent"/)'
             Write( *,strfmt)
@@ -616,7 +586,7 @@ Contains
             n=0
             i=0
         End Do
-        Open(13,file=FNAME,status='UNKNOWN',access='DIRECT',recl=2*IP6*IPmr)
+        Open(13,file=FNAME,status='UNKNOWN',access='DIRECT',recl=2*IP6*Mrec)
         Do ni=1,4
             Call ReadF (12,ni,P,Q,2)
             Call WriteF(13,ni,P,Q,2)
@@ -648,7 +618,7 @@ Contains
         Real(dp), Dimension(20) :: dd, ss
         Character(Len=512) :: strfmt
 
-        open(12,file=FNAME,status='OLD',access='DIRECT',recl=2*IP6*IPmr)
+        open(12,file=FNAME,status='OLD',access='DIRECT',recl=2*IP6*Mrec)
         Ecore=0.d0
         Hcore=0.d0
         ih=2-kt
@@ -965,7 +935,8 @@ Contains
     Subroutine Sint(ds)
         Implicit None
         Integer :: ih, i0, i1, i2, i3, i
-        Real(dp) :: h1, v0, r0, gam, r1, rr2, r3, t0, p0, f0, g, f1, f2, f3, f21, f32, f321, c0, c1, c2, dt, f, s, t, ds, q, hh, p1, p2, t1, t2
+        Real(dp) :: h1, v0, r0, gam, r1, rr2, r3, t0, p0, f0, g, f1, f2, f3, f21, f32, f321, &
+                    c0, c1, c2, dt, f, s, t, ds, q, hh, p1, p2, t1, t2
 
         gam=c(ii+4)
         ih=2-kt
@@ -1487,7 +1458,7 @@ Contains
         sg=0.d0               !### ME of Sigma
         br=0.d0               !### Breit ME
         nx = ns - Nsv + 1     !### parameter for indexation of integrals
-        irec=2*IP6*IPmr
+        irec=2*IP6*Mrec
         open(12,file=FNAME,status='OLD',access='DIRECT',recl=irec)
         open(13,file='HFD.DAT',status='OLD',access='DIRECT',recl=irec)
         call ReadF (12,1,Pa,Qa,2)
@@ -1620,13 +1591,14 @@ Contains
         Implicit None
 
         Integer :: Norb, iw, kcg, ksin, nj, nnj, llj, kkj, i1, n1, l1, kbk, nbk, &
-                    nnk, llk, jjk, kkk, nk, m1, mx, if, longbasis, itail, lort, nim, &
+                    nnk, llk, jjk, kkk, nk, m1, mx, if, itail, lort, nim, &
                     iwx, jjj, j1
         Real(dp) :: gj, qn
         Integer, Dimension(4*IPs) :: Iqn
         Real(dp), Dimension(IPs) :: Qq1
         Real(dp), Dimension(4*IP6) :: PQ
         Real(dp), Dimension(IP6) :: A, B, P, Q
+        Logical :: longbasis
 
         Character(Len=256) :: strfmt
         
@@ -1861,7 +1833,7 @@ Contains
         zmax=1.d-2                !### max |H_ik/(E_i-E_k)| gor idg=2
         trd=1.d-8                 !### convergence threshold
         nw=0
-        irec=2*IP6*IPmr
+        irec=2*IP6*Mrec
         nmin=Nsv+1
         nmin=max(nmin,N_orb(n1,ch1,j1)) !### define diagonalization domain
                                         !### if kdg=0, then energies are
@@ -2419,7 +2391,7 @@ Contains
         ! res - max residue
         Implicit None
 
-        Integer :: nd, nd1, nzx, k
+        Integer :: nd, nd1, nzx, k, n
         Real(dp) :: res, res1, s, e, zx, xk, a, a2, xd
         Real(dp), Dimension(nd1) :: D, X
         Real(dp), Dimension(nd1,nd1) :: H, Z
@@ -2553,7 +2525,7 @@ Contains
   
         write(*,*) ' Give file name for additional orbitals: '
         read(*,'(A12)') FNAME3
-        open(16,file=FNAME3,access='DIRECT',status='OLD',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        open(16,file=FNAME3,access='DIRECT',status='OLD',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             write( *,*) ' No file ',FNAME3
             write(11,*) ' No file ',FNAME3

--- a/src/check_matrices.f90
+++ b/src/check_matrices.f90
@@ -1,0 +1,50 @@
+program check_matrices
+    use, intrinsic :: iso_fortran_env, only : dp => real64, int64
+
+    implicit none
+
+    character(len=16) :: filename
+
+    print*, 'Enter matrix file (CONFp.HIJ or CONFp.JJJ) to check: '
+    read(*, *) filename
+    call read_matrix(filename)
+
+contains
+
+    subroutine read_matrix(filename)
+        ! read matrix element file written by pconf program using a single process
+        implicit none
+
+        character(len=*), intent(in) :: filename
+        integer(kind=int64) :: num_total_elements, num_zeros
+
+        integer(kind=int64) :: i
+        integer :: n, err_stat, num_procs, num_elements
+        character(len=16) :: err_msg, count_str
+        logical :: found_zero
+        
+        ! Read num_cores
+        open(unit=15,file='nprocs.conf',status='UNKNOWN',form='unformatted',access='stream',iostat=err_stat,iomsg=err_msg)
+        read(15) num_procs
+        close(15)
+    
+        Write(count_str, '(I4)') num_procs
+        print*, 'Number of processes used to write ', trim(adjustl(filename)), ': ', trim(adjustl(count_str))
+
+        open(unit=15,file=filename,status='OLD',form='unformatted',access='stream',iostat=err_stat,iomsg=err_msg)
+        num_total_elements = 0_int64
+        found_zero = .false.
+        do n = 1, num_procs
+            read(15) num_elements
+            if (num_elements == 0) then
+                print*, 'core', n-1, 'has 0 matrix elements!'
+                found_zero = .true.
+            end if
+            num_total_elements = num_total_elements + num_elements
+        end do
+        print*, 'Number of matrix elements in ', filename, ':', num_total_elements
+        if (found_zero) print*, 'WARNING: check results of pconf to see if number of matrix elements match'
+
+    end subroutine read_matrix
+
+end program check_matrices

--- a/src/conf_init.f90
+++ b/src/conf_init.f90
@@ -134,7 +134,7 @@ Module conf_init
         Implicit None
 
         integer :: index_equals, index_hashtag, err_stat
-        character(len=5) :: key
+        character(len=10) :: key
         character(len=10) :: val
         character(len=80) :: line
         logical :: equals_in_str
@@ -150,6 +150,7 @@ Module conf_init
         K_sms = 0
         KWeights = 0
         KXIJ = 10
+        MaxNd0 = 3000
         
         ! read parameters (lines with "=")
         equals_in_str = .true.
@@ -202,6 +203,9 @@ Module conf_init
                 Case('KWeights')
                     ! KWeights determines whether CONF.WGT is written (1) or not (0)
                     Read(val, *) KWeights
+                Case('MaxNd0')
+                    ! MaxNd0 determines the size of the initial approximation in determinants
+                    Read(val, *) MaxNd0
                 End Select
             End If
         End Do

--- a/src/conf_init.f90
+++ b/src/conf_init.f90
@@ -153,7 +153,7 @@ Module conf_init
         equals_in_str = .true.
         Do While (equals_in_str)
             Read(99, '(A)', iostat=err_stat) line
-            If (index(string=line, substring="=") == 0 .or. err_stat) Then
+            If (index(string=line, substring="=") == 0 .or. err_stat /= 0) Then
                 equals_in_str = .false.
             Else
                 index_equals = index(string=line, substring="=")
@@ -208,9 +208,9 @@ Module conf_init
     Subroutine ReadConfInp
         ! This subroutine reads input parameters from the header of CONF.INP
         Implicit None
-        Integer :: istr
+        
         Character(Len=1) :: name(16)
-        ! - - - - - - - - - - - - - - - - - - - - - -
+
         ! Optional parameters
         K_is = 0 
         C_is = 0.d0 
@@ -268,8 +268,6 @@ Module conf_init
         Implicit None
         Integer  :: i, i1, i2, ic, ne0, nx, ny, nz
         Real(dp) :: x
-        logical  :: equals_in_str
-        ! - - - - - - - - - - - - - - - - - - - - - -
         
         Call calcNsp
         Call GotoConfigurations
@@ -290,8 +288,8 @@ Module conf_init
                 Do i=i1,i2
                    x=abs(Qnl(i))+1.d-9
                    If (x < 1.d-8) Exit
-                   nx=10000*x
-                   ny=100*x
+                   nx=Int(10000*x)
+                   ny=Int(100*x)
                    nz=(nx-100*ny)
                    ne0=ne0+nz
                    If (mod(ny,10) > Nlx) Nlx=mod(ny,10) ! Set Nlx to be max partial wave
@@ -340,8 +338,8 @@ Module conf_init
                 Do i=1,num_orbitals_per_line
                    x=abs(line(i))+1.d-9
                    If (x < 1.d-8) Exit
-                   nx=10000*x
-                   ny=100*x
+                   nx=Int(10000*x)
+                   ny=Int(100*x)
                    nz=(nx-100*ny)
                    ne0=ne0+nz
                    counter = counter + 1

--- a/src/conf_init.f90
+++ b/src/conf_init.f90
@@ -148,6 +148,8 @@ Module conf_init
         Kw = 0
         KLSJ = 0
         K_sms = 0
+        KWeights = 0
+        KXIJ = 10
         
         ! read parameters (lines with "=")
         equals_in_str = .true.
@@ -193,6 +195,13 @@ Module conf_init
                     ! SMS to include 1-e (1), 2-e (2), or both (3)
                     Read(val, *) K_sms
                     ! Write(*,*) ' SMS to include 1-e (1), 2-e (2), both (3): ', K_sms
+                Case('KXIJ')
+                    ! KXIJ determines the interval in which CONF.XIJ will be written
+                    ! e.g. KXIJ=10 - CONF.XIJ is written every 10 Davidson iterations
+                    Read(val, *) KXIJ
+                Case('KWeights')
+                    ! KWeights determines whether CONF.WGT is written (1) or not (0)
+                    Read(val, *) KWeights
                 End Select
             End If
         End Do

--- a/src/conf_pt.f90
+++ b/src/conf_pt.f90
@@ -1153,7 +1153,7 @@ Contains
             Do ic=ic0,ic1
               kd=kd+Ndc(ic)
             End Do
-            If (kd4+kd > IP1) goto 100
+            If (kd4+kd > MaxNd0) goto 100
             kd4=kd4+kd
             kc4=kc4+NRN(icnr)
           End Do

--- a/src/conf_pt.f90
+++ b/src/conf_pt.f90
@@ -25,6 +25,8 @@ Program conf_pt
     integer, allocatable, dimension(:)    :: Ndcnr, Nvcnr, NRR, NRN, Ndirc
     real(dp), allocatable, dimension(:)   :: B1h, En, Xj, EnG, Ey, DEnr, DVnr
     real(dp), allocatable, dimension(:,:) :: X0
+    
+    Type(MPI_Datatype) :: mpi_type2_real
 
     !     - - - - - - - - - - - - - - - - - - - - - - - - -
     !
@@ -115,13 +117,13 @@ Contains
         ! Write name of program
         Select Case(type2_real)
         Case(sp)
-            strfmt = '(/4X,"Program CONF_PT v2.2", &
+            strfmt = '(/4X,"Program CONF_PT v2.3", &
                /4X,"PT corrections to binding energy", & 
                /4X,"Zero approximation is taken from CONF.XIJ", &
                /4X,"New vectors are in CONF_PT.XIJ and", &
                /4X,"new input is in CONF_new.INP")'
         Case(dp) 
-            strfmt = '(/4X,"Program CONF_PT v2.2 with double precision for 2e integrals", &
+            strfmt = '(/4X,"Program CONF_PT v2.3 with double precision for 2e integrals", &
                /4X,"PT corrections to binding energy", & 
                /4X,"Zero approximation is taken from CONF.XIJ", &
                /4X,"New vectors are in CONF_PT.XIJ and", &
@@ -162,6 +164,7 @@ Contains
     End Subroutine Input
 
     Subroutine Init
+        Use utils, Only : DetermineRecordLength
         Implicit None
         Integer                     :: ii, ni, If, nj, i, nnj, llj, jlj, kkj, err_stat, &
                                        nec, imax, j, n, ic, i0, nmin, i1, n2, n1, l
@@ -173,7 +176,8 @@ Contains
         Integer, Dimension(33)      :: nnn, jjj, nqq
         Character(Len=1)            :: Let(9), lll(33)
         Character(Len=512)          :: strfmt, err_msg
-        Logical                     :: longbasis
+        Logical                     :: longbasis, success
+
         equivalence (IQN(1),PQ(21)),(Qq1(1),PQ(2*IPs+21))
         equivalence (p(1),pq(1)), (q(1),pq(IP6+1)), &
                     (p1(1),pq(2*IP6+1)), (q1(1),pq(3*IP6+1))
@@ -182,7 +186,13 @@ Contains
         c1 = 0.01d0
         mj = 2*abs(Jm)+0.01d0
 
-        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        Call DetermineRecordLength(Mrec, success)
+        If (.not. success) Then
+            Write(*,*) 'ERROR: record length could not be determined'
+            Stop
+        End If
+
+        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             strfmt='(/2X,"file CONF.DAT is absent"/)'
             Write( *,strfmt)
@@ -471,7 +481,7 @@ Contains
         Call BroadcastI(Iint2, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint3, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(IntOrd, nrd, MPI_INTEGER8, 0, MPI_COMM_WORLD, mpierr)
-        Call BroadcastD(Rint2, count, 0, 0, MPI_COMM_WORLD, mpierr)
+        Call BroadcastD(Rint2, count, 0, mpi_type2_real, 0, MPI_COMM_WORLD, mpierr)
         count = Ne*Int(Nd,kind=int64)
         Call BroadcastI(Iarr, count, 0, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(In, Ngaunt, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)

--- a/src/conf_variables.f90
+++ b/src/conf_variables.f90
@@ -31,14 +31,18 @@ Module conf_variables
     Real(dp), Allocatable, Dimension(:)    :: Gnt, Rint1, Tl, Ts, D
     Real(dp), Allocatable, Dimension(:,:)  :: W
 
+    ! Set type_real to determine whether to use single precision (sp) or double precision (dp) for Hamiltonian
+    Integer, Parameter :: type_real=dp
+
+    ! Set type2_real to determine whether to use single precision (sp) or double precision (dp) for two-electron and IS integrals
+    Integer, Parameter :: type2_real=sp
+    
     Real(type2_real), Allocatable, Dimension(:)    :: Rsig, Dsig, Esig, Rint2S, Dint2S, Eint2S, R_is, Scr
     Real(type2_real), Allocatable, Dimension(:,:)  :: Rint2
     
     Real(type_real),  Allocatable, Dimension(:,:) :: ArrB, P, Z1
     Real(type_real),  Allocatable, Dimension(:) :: Diag, Tj, Tk, E, E1
-
-    Real(dp), Dimension(IPs)   :: Eps
-    Real(dp), Dimension(IP1)   :: C
+    Real(type_real), Allocatable, Dimension(:) :: B1, B2
 
     Type :: Matrix(knd)
         Integer, kind :: knd

--- a/src/conf_variables.f90
+++ b/src/conf_variables.f90
@@ -6,7 +6,7 @@ Module conf_variables
     
     Public
 
-    Integer             :: Kexn=0, Ksig=0, Kdsig=0, K_prj=0, K_sms=0, Kw=0, kLSJ=0, KXIJ, KWeights
+    Integer             :: Kexn=0, Ksig=0, Kdsig=0, K_prj=0, K_sms=0, Kw=0, kLSJ=0, KXIJ, KWeights, MaxNd0
     Integer             :: NmaxS=0, LmaxS=0, Nhint=0, NhintS=0, NgintS=0
     Integer             :: IPlv, nrd, kdavidson, num_is, Nc1, Nc_prev, Nd_prev
     Integer             :: Kherr=0, Kgerr=0, Lmax, Kmax, Ksym, Nsum, Nnr

--- a/src/conf_variables.f90
+++ b/src/conf_variables.f90
@@ -6,16 +6,7 @@ Module conf_variables
     
     Public
 
-    ! Set kXIJ to determine the interval in which CONF.XIJ will be written
-    ! e.g. kXIJ=10 - CONF.XIJ is written every 10 Davidson iterations
-    Integer, Parameter :: kXIJ=10
-    
-    ! Set kWeights to determine whether CONF.WGT is written or not
-    ! If kWeights=0, then CONF.WGT is not written
-    ! If kWeights=1, then CONF.WGT is written
-    Integer, Parameter :: kWeights=0
-
-    Integer             :: Kexn=0, Ksig=0, Kdsig=0, K_prj=0, K_sms=0, Kw=0, kLSJ=0
+    Integer             :: Kexn=0, Ksig=0, Kdsig=0, K_prj=0, K_sms=0, Kw=0, kLSJ=0, KXIJ, KWeights
     Integer             :: NmaxS=0, LmaxS=0, Nhint=0, NhintS=0, NgintS=0
     Integer             :: IPlv, nrd, kdavidson, num_is, Nc1, Nc_prev, Nd_prev
     Integer             :: Kherr=0, Kgerr=0, Lmax, Kmax, Ksym, Nsum, Nnr

--- a/src/conf_variables.f90
+++ b/src/conf_variables.f90
@@ -40,7 +40,7 @@ Module conf_variables
     Real(dp), Dimension(IPs)   :: Eps
     Real(dp), Dimension(IP1)   :: C
 
-    Type Matrix(knd)
+    Type :: Matrix(knd)
         Integer, kind :: knd
         Real(kind=knd) :: minval
         Integer,  Allocatable, Dimension(:) :: ind1, ind2

--- a/src/davidson.f90
+++ b/src/davidson.f90
@@ -11,7 +11,7 @@ Module davidson
 
   Contains
     
-    Subroutine Init4(mype)
+    Subroutine Init4(mype, mpi_type_real)
         ! This subroutine constructs the initial approximation 
         ! by selecting configurations specified by parameter Nc4.
         ! The initial approximation Hamilonian is stored in the 
@@ -22,6 +22,8 @@ Module davidson
         Use determinants, Only : calcNd0
         Use str_fmt, Only : FormattedTime, startTimer, stopTimer
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer  :: k, n, mype, mpierr
         Integer(Kind=int64) :: l8, s1
         Real(type_real) :: t
@@ -64,12 +66,12 @@ Module davidson
 
         If (mype == 0) Then
             Call stopTimer(s1, timeStr)
-            Write(*,'(2X,A)'), 'TIMING >>> Initial approximation constructed in '// trim(timeStr)
+            Write(*,'(2X,A)') 'TIMING >>> Initial approximation constructed in '// trim(timeStr)
         End If
 
     End Subroutine Init4
 
-    Subroutine FormB0(mype)
+    Subroutine FormB0(mype, mpi_type_real)
         ! This subroutine constructs the initial eigenvectors for the Davidson iteration
         ! and stores them in the first block of ArrB.
         ! Eigenvectors are written to CONF.XIJ 
@@ -77,6 +79,8 @@ Module davidson
         Use formj2, Only : J_av
         Use str_fmt, Only : FormattedTime, startTimer, stopTimer
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer :: i, j, idum, ndpt, ierr, num, nskip, mpierr, mype
         Integer(kind=int64) :: s1
         Real(dp) :: dummy
@@ -98,7 +102,7 @@ Module davidson
         If (abs(Kl4) /= 2) Then ! If not reading CONF.XIJ
             Do j=1,Nd0
                 B1(1:Nd0)=Z1(1:Nd0,j)
-                Call J_av(B1,Nd0,xj,ierr)
+                Call J_av(B1,Nd0,xj,mpi_type_real,ierr)
                 If (ierr == 0) Then
                     num=num+1
                     E(num)=-(E1(j)+Hamil%minval)
@@ -140,7 +144,7 @@ Module davidson
                 Write(11,*) ' Selection is done', nskip,' vectors skiped'
             End If
             Call stopTimer(s1, timeStr)
-            Write(*,'(2X,A)'), 'TIMING >>> Initial eigenvectors constructed in '// trim(timeStr) // '.'
+            Write(*,'(2X,A)') 'TIMING >>> Initial eigenvectors constructed in '// trim(timeStr) // '.'
         End If
         
         Return
@@ -377,13 +381,15 @@ Module davidson
         Return
     End Subroutine Dvdsn
 
-    Subroutine Mxmpy(ip, mype)
+    Subroutine Mxmpy(ip, mpi_type_real, mype)
         ! This subroutine evaluates the products Q_i = H_ij * B_j
         ! if ip=1, products are stored in the second block of ArrB
         ! if ip=2, products are stored in the third block of ArrB
         Use mpi_f08
         Use mpi_utils, Only : BroadcastD
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer, Intent(In) :: ip, mype
 
         Integer :: i, k, nlp, n, mpierr, i2min, i2max, i1min, i1max, kd
@@ -420,7 +426,6 @@ Module davidson
                 t=t-Hamil%minval
                 If (kd == 1) Diag(n)=t
             End If
-            !If (devmode == 1 .and. mype == 1) print*, n, k, t, ArrB(n,i2min:i2max)
             ArrB(n,i2min:i2max)=ArrB(n,i2min:i2max)+t*ArrB(k,i1min:i1max)
             If (n /= k) ArrB(k,i2min:i2max)=ArrB(k,i2min:i2max)+t*ArrB(n,i1min:i1max)
         End Do
@@ -505,12 +510,15 @@ Module davidson
         Return
     End Subroutine Ortn
 
-    Subroutine Prj_J(lin, num, lout, trsd, mype) 
+    Subroutine Prj_J(lin, num, lout, trsd, mpi_type_real, mype) 
         Use mpi_f08
         Use determinants, Only : Gdet
         Implicit None
+
+        Type(MPI_Datatype) :: mpi_type_real
         Integer :: ierr, i, n, k, j, i2, i1, jx, it, iter, lout, num, lin, jav, mpierr, imin, imax
         Integer, optional :: mype
+        Integer(kind=int64) :: j8
         Real(dp) :: err1, err, f, trsd
         Real(type_real) :: t, sj, aj, s, s1, a
         logical :: proceed
@@ -523,7 +531,7 @@ Module davidson
             Write(11,strfmt) Nlv,lout+num-1,IPlv
             Stop
         End If
-        jav=2*XJ_av+0.1d0
+        jav=Int(2*XJ_av+0.1d0)
         If (mype == 0) Then
             strfmt = '(4X,"Prj_J: projecting",I3," vectors on subspace J=",F5.1)'
             Write( *,strfmt) num,XJ_av
@@ -548,10 +556,10 @@ Module davidson
                     i2=lout+i-1
                     ArrB(1:Nd,i2)=0_type_real
                 End Do
-                Do j=1,ij8
-                    n=Jsq%ind1(j)
-                    k=Jsq%ind2(j)
-                    t=Jsq%val(j)
+                Do j8=1,ij8
+                    n=Jsq%ind1(j8)
+                    k=Jsq%ind2(j8)
+                    t=Jsq%val(j8)
                     Do i=1,num
                         proceed=(lin-1)*Iconverge(i)==0
                         If (proceed) Then

--- a/src/davidson.f90
+++ b/src/davidson.f90
@@ -322,8 +322,11 @@ Module davidson
 
         Integer :: j1, i, k, n01
         Real(type_real) :: val, t, cnorm, s
+        Real(type_real), Dimension(:), Allocatable :: C
         character(len=9) :: char
 
+        If (.not. Allocated(C)) Allocate(C(Nd0))
+        
         cnorm=0_type_real
         j1=j+Nlv
         val=P(j,j)
@@ -378,6 +381,9 @@ Module davidson
         End Do
         s=1.d0/dsqrt(s)
         ArrB(1:Nd,J1)=B1(1:Nd)*s
+
+        If (Allocated(C)) Deallocate(C)
+
         Return
     End Subroutine Dvdsn
 

--- a/src/davidson.f90
+++ b/src/davidson.f90
@@ -136,7 +136,7 @@ Module davidson
                 strfmt = '(1X,"E(",I3,") =",F12.6," Jtot =",F10.6)'
                 Write( 6,strfmt) j,E(j),Tj(j)
                 Write(11,strfmt) j,E(j),Tj(j)
-                If (kXIJ > 0) Write(17) E(j),Tj(j),Nd,(ArrB(i,j),i=1,Nd)
+                If (KXIJ > 0) Write(17) E(j),Tj(j),Nd,(ArrB(i,j),i=1,Nd)
             End Do
             close (unit=17)
             If (nskip > 0) Then

--- a/src/determinants.f90
+++ b/src/determinants.f90
@@ -19,7 +19,7 @@ Module determinants
         Integer :: ic, n1, n0
 
         ic1=0
-        n0=IP1+1
+        n0=MaxNd0+1
         n1=0
 
         Do ic=1,Nc4

--- a/src/determinants.f90
+++ b/src/determinants.f90
@@ -96,7 +96,7 @@ Module determinants
     Subroutine Jterm
         Implicit None
 
-        Integer         :: i, j, mt, n, im, ndi, nd1, imax, iconf, ndi1, iconf1, jmax
+        Integer         :: j, mt, n, im, ndi, nd1, imax, iconf, ndi1, iconf1, jmax
         Real(dp)        :: d
         Integer, allocatable, dimension(:) :: idet, nmj
         logical :: fin, swapped
@@ -492,7 +492,7 @@ Module determinants
         ! it does NOT post-process the located indices to determine scaling factor (is) or
         ! correct differing indices
         !
-        ! The two Integer index vectors, "i" and "j", are three elements in size and are
+        ! The two integer index vectors, "i" and "j", are three elements in size and are
         ! used as:
         !
         !     i(1)        running index over comparison

--- a/src/diff.f90
+++ b/src/diff.f90
@@ -14,9 +14,9 @@ Module diff
         ! This subroutine should be used for functions which are not very smooth at R=R(1).
         Implicit None
 
-        Integer :: i, ii, ih, im, ix, j, i1, ih2, ih3, ih4, ih5, ih6, ierr, kap, kt, MaxT
+        Integer :: i, ii, ih, im, ix, j, i1, ih2, ih3, ih4, ih5, ih6, ierr, kap, kt, MaxT, m
         Real(dp) :: h60, gm, r1, cp1, p1, pim, scale, err, h
-        Real(dp), Dimension(IP6) :: P, CP, R, V                 !
+        Real(dp), Dimension(IP6) :: P, CP, R, V
 
         If (MaxT.EQ.0) MaxT=9      !### hfd uses Nmax instead of MaxT
         ih=2-kt
@@ -111,7 +111,7 @@ Module diff
         If (dabs(err).GT.1.d-1) Then
             Write(*,'(4X,"Dif: matching error at R1. Taylor:",E12.5, &
                    ", Num:",E12.5,/4X,"Using Origin for new expansion.")') cp1,CP(1)
-            Ierr=Ierr+10*dabs(err)
+            ierr=ierr+10*Int(dabs(err))
             If (dabs(CP(ii+5)).GT.dabs(CP(ii+6))) Then
                 kap=1                            ! For kap>0 expansion
             Else                                 ! goes over even powers
@@ -176,6 +176,7 @@ Module diff
         If (MaxT.EQ.0) MaxT=9        !### hfd uses Nmax instead of MaxT
 
         P(ii+5:ii+5+MaxT)=0.d0
+        ierr=0
 
         If (P(1).EQ.0.d0) Return
 
@@ -226,7 +227,7 @@ Module diff
         pr2=rk*(c0+c1*y+c2*y*y+c3*y**3)*R(2)**gam / P(2) !# should be equal to 1
         dr2=rk*(g*c0+(g+2)*c1*y+(g+4)*c2*y*y+(g+6)*c3*y**3)*R(2)**(gam-1) / dp2    
 
-        ier=1.d6*(dabs(pr1-1.d0)+dabs(dr1-1.d0)+dabs(pr2-1.d0)+dabs(dr2-1.d0))
+        ier=Int(1.d6*(dabs(pr1-1.d0)+dabs(dr1-1.d0)+dabs(pr2-1.d0)+dabs(dr2-1.d0)))
         If (ier.GE.1) Then
             strfmt='(4X,"Expansion error for gam = ",F5.1," kap = ",I2, &
                 /4X,"pr1 = ",E15.7," dr1 = ",E15.7 &

--- a/src/env_var.f90
+++ b/src/env_var.f90
@@ -34,9 +34,11 @@ Module env_var
         GetEnvLogical = defaultValue
         Call GetEnv(varName, varValue)
         If (Len_Trim(varValue) > 0) then
-            If (varValue == 'y' .or. varValue == 'Y' .or. varValue == 'yes' .or. varValue == 'YES' .or. varValue == 't' .or. varValue == 'T' .or. varValue == 'true' .or. varValue == 'TRUE') then
+            If (varValue == 'y' .or. varValue == 'Y' .or. varValue == 'yes' .or. varValue == 'YES' &
+                .or. varValue == 't' .or. varValue == 'T' .or. varValue == 'true' .or. varValue == 'TRUE') then
                 GetEnvLogical = .true.
-            Else If (varValue == 'n' .or. varValue == 'N' .or. varValue == 'no' .or. varValue == 'NO' .or. varValue == 'f' .or. varValue == 'F' .or. varValue == 'false' .or. varValue == 'FALSE') then
+            Else If (varValue == 'n' .or. varValue == 'N' .or. varValue == 'no' .or. varValue == 'NO' .or. &
+                    varValue == 'f' .or. varValue == 'F' .or. varValue == 'false' .or. varValue == 'FALSE') then
                 GetEnvLogical = .false.
             Else
                 Read(varValue,*,iostat=convStat) iValue

--- a/src/formy.f90
+++ b/src/formy.f90
@@ -1,5 +1,5 @@
 program formy
-    use params, IP1conf => IP1
+    use params
     use determinants, only : Dinit, Jterm
     use str_fmt, only : startTimer, stopTimer, FormattedTime
     use mpi_f08

--- a/src/formy.f90
+++ b/src/formy.f90
@@ -1,5 +1,5 @@
 program formy
-    use params, ipmr1 => IPmr, IP1conf => IP1
+    use params, IP1conf => IP1
     use determinants, only : Dinit, Jterm
     use str_fmt, only : startTimer, stopTimer, FormattedTime
     use mpi_f08
@@ -44,9 +44,8 @@ program formy
     call BcastVector(mype)
     call Vector(kl,mype)                   !###  the equation and vectors Yi
 
-    
     call stopTimer(start_time, timeStr)
-    If (mype == 0) write(*,'(2X,A)'), 'TIMING >>> Total computation time of ine was '// trim(timeStr)
+    If (mype == 0) write(*,'(2X,A)') 'TIMING >>> Total computation time of formy was '// trim(timeStr)
 
     call MPI_Finalize(mpierr)
 
@@ -490,7 +489,7 @@ contains
           Write(*,'(A,1pD8.1)')' W00=',W00
         End If
 
-        strfmt = '(1X,70("#"),/1X,"Program FormY v1.0",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
+        strfmt = '(1X,70("#"),/1X,"Program FormY v1.1",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
         Write( 6,strfmt) str(kli),str(klf)
         Write(11,strfmt) str(kli),str(klf)
 

--- a/src/ine.f90
+++ b/src/ine.f90
@@ -51,7 +51,7 @@ Program ine
     !         General convention: GLOBAL VARIABLES     |||
     !              ARE CAPITALISED                     |||
     ! ||||||||||||||||||||||||||||||||||||||||||||||||||||
-    Use params, IP1conf => IP1
+    Use params
     Use determinants, Only : Dinit, Jterm
     Use str_fmt, Only : startTimer, stopTimer
 

--- a/src/ine.f90
+++ b/src/ine.f90
@@ -51,7 +51,7 @@ Program ine
     !         General convention: GLOBAL VARIABLES     |||
     !              ARE CAPITALISED                     |||
     ! ||||||||||||||||||||||||||||||||||||||||||||||||||||
-    Use params, ipmr1 => IPmr, IP1conf => IP1
+    Use params, IP1conf => IP1
     Use determinants, Only : Dinit, Jterm
     Use str_fmt, Only : startTimer, stopTimer
 
@@ -202,7 +202,7 @@ Program ine
     Close(unit=11) ! Close INE.RES
     Close(unit=99) ! Close INEFINAL.RES
     Call stopTimer(start_time, timeStr)
-    Write(*,'(2X,A)'), 'TIMING >>> Total computation time of ine was '// trim(timeStr)
+    Write(*,'(2X,A)') 'TIMING >>> Total computation time of ine was '// trim(timeStr)
     
 Contains
 
@@ -365,7 +365,7 @@ Contains
           Write(*,'(A,1pD8.1)')' W00=',W00
         End If
 
-        strfmt = '(1X,70("#"),/1X,"Program InhomEq. v1.23",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
+        strfmt = '(1X,70("#"),/1X,"Program InhomEq. v1.24",5X,"R.H.S.: ",A5," L.H.S.: ",A5)'
         Write( 6,strfmt) str(kli),str(klf)
         Write(11,strfmt) str(kli),str(klf)
 
@@ -946,7 +946,7 @@ Contains
         If (.not. Allocated(Hamil%t)) Allocate(Hamil%t(NumH))
         cnt=0
         Do i8=1,NumH
-            Read(15), Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
+            Read(15) Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
             if (Hamil%n(i8) == Nd + 1) then
                 NumH=cnt
                 print*,'For Nd=',Nd,', NumH=', NumH
@@ -1090,7 +1090,7 @@ Contains
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
         
         strfmt = '(3X," NumH =",I12,";  Hmin =",F12.6/)'
         Write(*,strfmt) NumH,Hmin
@@ -1124,14 +1124,14 @@ Contains
         Call system_clock(end2)
         ttime2=Real((end2-start2)/clock_rate)
         Call FormattedTime(ttime2, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Zspsv in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Zspsv in '// trim(timeStr)// '.'
 
         X1= 0.d0 
         X1(1:Ntr)= Real(XX1(1:Ntr), kind=dp)
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: decomp in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: decomp in '// trim(timeStr)// '.'
 
         ! Orthogonalization of X1 to X0 (If J0 /= 0)
         If (Kli.EQ.5 .AND. dabs(Tj0).GT.0.51d0) Call Ort  

--- a/src/integrals.f90
+++ b/src/integrals.f90
@@ -13,7 +13,7 @@ Module integrals
     subroutine Rint
         Implicit None
         Integer     :: i, nsh, ns1, nso1, nsu1, nsp1, Nlist, &
-                       k, mlow, m_is, err_stat, kbrt1, nx1
+                       k, mlow, m_is, err_stat, kbrt1
         Integer(Kind=int64) :: i8
         Character*7 :: str(3),str1(4)*4
         Character(Len=3) :: key1, key2
@@ -162,18 +162,20 @@ Module integrals
     Real(dp) Function Gint(i1,i2,i3,i4)
         Implicit None
         Integer  :: i2, ib, i1, ia, is, la, nd, nc, nb, na, md, mc, mb, ma, &
-                    is_sms, ii, i4, id, i3, ic, iac, k1, is_br, i_br, minint, &
+                    is_sms, ii, i4, id, i3, ic, iac, k1, is_br, i_br, &
                     iab, kmax, kmin, ibd0, iac0, k, jd, jc, jb, ja, ibr, i, ld, &
-                    lc, lb, ibd, kac, kbd, mi
-        Integer(Kind=int64) :: i8, mi8, minint8=0_int64
+                    lc, lb, ibd, kac, kbd
+        Integer(Kind=int64) :: i8, mi8, minint8
         Real(dp) :: e, rabcd
         Logical  :: l_is, l_br, l_pr
         Character(Len=256) :: strfmt
-        ! - - - - - - - - - - - - - - - - - - - - - - - - -
+
         l_is= .not. (C_is == 0.d0)                ! False If C_is=0
         l_is=l_is .and. (K_is == 2 .or. K_is == 4)  ! False If K_is /= 2,4
         l_is=l_is .and. (K_sms >= 2)              ! False If K_sms<2
         l_br=Kbrt /= 0
+
+        minint8=0_int64
         e=0.d0
         is=1
         ia=i1
@@ -616,7 +618,7 @@ Module integrals
         m2=xm2
         is = 1
         g = 0.d0
-        im = abs(m2-m1)
+        im = Int(abs(m2-m1))
         If (k >= im) Then
             If (k == 0) Then
                 If (j1 == j2) Then
@@ -637,12 +639,12 @@ Module integrals
                 If (m1 <= 0.d0) Then
                    m1 = -m1
                    m2 = -m2
-                   ij = k+j1-j2
+                   ij = Int(k+j1-j2)
                    If(ij /= 2*(ij/2)) is = -is
                 End If
                 ib1=2*Nlx+1
                 ib2=ib1*ib1
-                ind = ib2*(ib2*k+2*(ib1*j1+j2))+ib1*(j1+m1)+(j2+m2)
+                ind = Int(ib2*(ib2*k+2*(ib1*j1+j2))+ib1*(j1+m1)+(j2+m2))
                 ! TODO - use num_gaunts_per_partial_wave to start looking for gaunt factors in their respective blocks of l
                 Do i=1,Ngaunt
                    If(In(i) == ind) Then

--- a/src/mpi_utils.f90
+++ b/src/mpi_utils.f90
@@ -13,7 +13,7 @@ Module mpi_utils
     ! exceeds the maximum threshold, the maximum threshold is used.  The
     ! maximum equates to 1 GiB worth of elements.
     !
-    Use params
+    Use conf_variables
 
     Implicit None
     

--- a/src/mpi_utils.f90
+++ b/src/mpi_utils.f90
@@ -29,7 +29,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                  :: comm
         Integer(Kind=int64), Intent(In)             :: count
         Integer, Intent(In)                         :: stride, rank
@@ -40,8 +39,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -73,7 +72,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                  :: comm
         Integer(Kind=int64), Intent(In)             :: count
         Integer, Intent(In)                         :: stride, rank
@@ -84,8 +82,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -114,11 +112,11 @@ Module mpi_utils
         End If
     End Subroutine BroadcastR
 
-    Subroutine BroadcastD(buffer, count, stride, rank, comm, mpierr)
+    Subroutine BroadcastD(buffer, count, stride, mpi_rtype, rank, comm, mpierr)
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
+        Type(MPI_Datatype), Intent(In)              :: mpi_rtype
         Type(MPI_Comm), Intent(In)                  :: comm
         Integer(Kind=int64), Intent(In)             :: count
         Integer, Intent(In)                         :: stride, rank
@@ -129,8 +127,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) Then
                 use_stride = MaxStride8Byte
                 If (type2_real == sp) use_stride = use_stride * 2
@@ -148,7 +146,7 @@ Module mpi_utils
         i = 1_int64
         mpierr = 0
         Do While (count_remain .gt. use_stride)
-            Call MPI_Bcast(buffer(i:i+use_stride), use_stride, mpi_type2_real, rank, comm, mpierr)
+            Call MPI_Bcast(buffer(i:i+use_stride), use_stride, mpi_rtype, rank, comm, mpierr)
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure broadcasting real range ',i,':',i+use_stride
                 Return
@@ -158,7 +156,7 @@ Module mpi_utils
         End Do
         If (count_remain .gt. 0) Then
             count_remain2 = count_remain
-            Call MPI_Bcast(buffer(i:i+count_remain2), count_remain2, mpi_type2_real, rank, comm, mpierr)
+            Call MPI_Bcast(buffer(i:i+count_remain2), count_remain2, mpi_rtype, rank, comm, mpierr)
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure broadcasting real range ',i,':',i+use_stride
                 Return
@@ -170,7 +168,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                  :: comm
         Type(MPI_Op), Intent(In)                    :: op
         Integer(Kind=int64), Intent(In)             :: count
@@ -182,8 +179,8 @@ Module mpi_utils
         Integer                                     :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -211,11 +208,11 @@ Module mpi_utils
         End If
     End Subroutine AllReduceI
 
-    Subroutine AllReduceR(buffer, count, stride, op, comm, mpierr)
+    Subroutine AllReduceR(buffer, count, stride, mpi_rtype, op, comm, mpierr)
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
+        Type(MPI_Datatype), Intent(In)                 :: mpi_rtype
         Type(MPI_Comm), Intent(In)                     :: comm
         Type(MPI_Op), Intent(In)                       :: op
         Integer(Kind=int64), Intent(In)                :: count
@@ -227,8 +224,8 @@ Module mpi_utils
         Integer                                        :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride
@@ -238,7 +235,7 @@ Module mpi_utils
         i = 1_int64
         mpierr = 0
         Do While (count_remain .gt. use_stride)
-            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+use_stride), use_stride, mpi_type2_real, op, comm, mpierr) 
+            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+use_stride), use_stride, mpi_rtype, op, comm, mpierr) 
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure reducing real range ',i,':',i+use_stride
                 Return
@@ -248,7 +245,7 @@ Module mpi_utils
         End Do
         If (count_remain .gt. 0) Then
             count_remain2 = count_remain
-            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+count_remain2), count_remain2, mpi_type2_real, op, comm, mpierr) 
+            Call MPI_AllReduce(MPI_IN_PLACE, buffer(i:i+count_remain2), count_remain2, mpi_rtype, op, comm, mpierr) 
             If (mpierr .ne. 0 ) Then
                 Write(*,*) 'Failure reducing real range ',i,':',i+use_stride
                 Return
@@ -260,7 +257,6 @@ Module mpi_utils
         Use mpi_f08
         Implicit None
 
-        EXTERNAL :: GetEnv
         Type(MPI_Comm), Intent(In)                     :: comm
         Type(MPI_Op), Intent(In)                       :: op
         Integer(Kind=int64), Intent(In)                :: count
@@ -272,8 +268,8 @@ Module mpi_utils
         Integer                                        :: count_remain2, use_stride
 
         If (stride .le. 0) Then
-            Call GetEnv('CONF_BROADCAST_MAX', envvar)
-            Read(envvar, '(i)') use_stride
+            Call get_environment_variable('CONF_BROADCAST_MAX', envvar)
+            Read(envvar, '(i10)') use_stride
             If (use_stride .le. 0) use_stride = MaxStride8Byte * 2
         Else
             use_stride = stride

--- a/src/params.f90
+++ b/src/params.f90
@@ -28,7 +28,6 @@ Module params
     !                     Array dimension          Associated variable
     Integer, Parameter :: IPs   =    600         ! Ns - number of orbitals
     Integer, Parameter :: IPx   =    440         ! Nx - used for indexation of integrals   
-    Integer, Parameter :: IP1   =   3000         ! Nd1 - number of determinants for direct diagonalization   
 
     ! defining parameters which determine dimensions of main arrays in hfd
     Integer, Parameter :: IP6   =    470         ! record length for DAT files

--- a/src/params.f90
+++ b/src/params.f90
@@ -32,12 +32,6 @@ Module params
 
     ! defining parameters which determine dimensions of main arrays in hfd
     Integer, Parameter :: IP6   =    470         ! record length for DAT files
-
-    ! Set type_real to determine whether to use single precision (sp) or double precision (dp) for Hamiltonian
-    Integer, Parameter :: type_real=dp
-
-    ! Set type2_real to determine whether to use single precision (sp) or double precision (dp) for two-electron and IS integrals
-    Integer, Parameter :: type2_real=sp
     
     ! Global variables 
     Integer :: Ns, Nsp, Nso, Nsu, Ne, Nec, Nc, Nc4, Nd, Nlv, Ndr, Njd, Nst, Ncpt, N_it, Ngaunt, M, Mj, Mrec
@@ -50,8 +44,7 @@ Module params
     Integer, Allocatable, Dimension(:)    :: Jz, Nh, Nh0, Nip, Nq, Nq0, Nc0, Ndc, Nvc, Jtc
     Real(dp), Allocatable, Dimension(:)   :: D1, Qnl
     Integer, Allocatable, Dimension(:,:)  :: Iarr
-
-    Real(type_real), Allocatable, Dimension(:) :: B1, B2
+    Real(dp), Dimension(IPs)              :: Eps
 
     Save
                                        

--- a/src/params.f90
+++ b/src/params.f90
@@ -4,8 +4,7 @@ Module params
     !                      parameters determining dimensions of arrays,
     !                      and global variables and arrays used in parallel programs
     !
-    Use, Intrinsic :: iso_fortran_env, Only : sp => real32, dp => real64, int64
-    Use mpi_f08, Only : MPI_Datatype
+    Use, Intrinsic :: iso_fortran_env, Only : sp => real32, dp => real64, int32, int64
 
     Implicit None
     
@@ -33,23 +32,15 @@ Module params
 
     ! defining parameters which determine dimensions of main arrays in hfd
     Integer, Parameter :: IP6   =    470         ! record length for DAT files
-    Integer, Parameter :: IPmr  =      1         ! word length in direct access files
-                                                 ! =4 if word=1B (Pentium)
-                                                 ! =1 if word=4B (Alpha-processor)   
 
     ! Set type_real to determine whether to use single precision (sp) or double precision (dp) for Hamiltonian
     Integer, Parameter :: type_real=dp
-    Type(MPI_Datatype) :: mpi_type_real
 
     ! Set type2_real to determine whether to use single precision (sp) or double precision (dp) for two-electron and IS integrals
     Integer, Parameter :: type2_real=sp
-    Type(MPI_Datatype) :: mpi_type2_real
-
-    ! Set key to turn on extra outputs for developing
-    Integer, Parameter :: devmode=1
     
     ! Global variables 
-    Integer :: Ns, Nsp, Nso, Nsu, Ne, Nec, Nc, Nc4, Nd, Nlv, Ndr, Njd, Nst, Ncpt, N_it, Ngaunt, M, Mj
+    Integer :: Ns, Nsp, Nso, Nsu, Ne, Nec, Nc, Nc4, Nd, Nlv, Ndr, Njd, Nst, Ncpt, N_it, Ngaunt, M, Mj, Mrec
     Integer :: Kl, Kl4, Klow, Kc, Kv, Kbrt, Kout, Kecp, K_is, Kautobas, Jdel, Nx
     Real(dp) :: Z, H, Gj, gnuc, Rnuc, Qnuc, Cut0, C_is, Am, Jm, Crt4
 

--- a/src/pconf.F90
+++ b/src/pconf.F90
@@ -838,7 +838,7 @@ Contains
         memStaticArrays = memStaticArrays! + 209700000_int64 ! static "buffer" of 200 MiB 
         memStaticArrays = memStaticArrays + sizeof(Nn)+sizeof(Kk)+sizeof(Ll)+sizeof(Jj)+sizeof(Nf0) &
                         + sizeof(Jt)+sizeof(Njt)+sizeof(Eps)+sizeof(Diag)+sizeof(Ndc)+sizeof(Jz) &
-                        + sizeof(Nh)+sizeof(In)+sizeof(Gnt)+sizeof(C)+(8+type_real)*vaBinSize
+                        + sizeof(Nh)+sizeof(In)+sizeof(Gnt)+(8+type_real)*vaBinSize
 
     End Subroutine calcMemStaticArrays
 

--- a/src/pconf.F90
+++ b/src/pconf.F90
@@ -897,6 +897,8 @@ Contains
         Integer(Kind=int64) :: count
 
         Call MPI_Barrier(MPI_COMM_WORLD, mpierr)
+        Call MPI_Bcast(KXIJ, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
+        Call MPI_Bcast(KWeights, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(KLSJ, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(Kv, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(N_it, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
@@ -1869,11 +1871,11 @@ Contains
                     End If
                     
                     Call MPI_Bcast(ax, 1, mpi_type_real, 0, MPI_COMM_WORLD, mpierr)
-                    ! Write intermediate CONF.XIJ in frequency of kXIJ
+                    ! Write intermediate CONF.XIJ in frequency of KXIJ
                     Call startTimer(s1)
-                    If (kXIJ > 0) Then
-                        ! Only write each kXIJ iteration
-                        If (mod(it, kXIJ) == 0) Then 
+                    If (KXIJ > 0) Then
+                        ! Only write each KXIJ iteration
+                        If (mod(it, KXIJ) == 0) Then 
                             ! Calculate J for each energy level
                             Do n=1,Nlv
                                 Call MPI_Bcast(ArrB(1:Nd,n), Nd, mpi_type_real, 0, MPI_COMM_WORLD, mpierr)
@@ -1954,7 +1956,7 @@ Contains
         data strsms/'(1-e) ','(2-e) ','(full)','      '/
         data strms/'SMS','NMS',' MS'/
 
-        If (iter <= kXIJ) Then
+        If (iter <= KXIJ) Then
             Open(unit=81,status='REPLACE',file='CONF.ENG',action='WRITE')
         Else
             Open(unit=81,status='UNKNOWN',POSITION='APPEND',file='CONF.ENG',action='WRITE')
@@ -2048,7 +2050,7 @@ Contains
         If (.not. Allocated(Wpsave)) Allocate(Wpsave(nconfs,Nlv))
         If (.not. Allocated(strcsave)) Allocate(strcsave(nconfs,Nlv))
 
-        If (iter <= kXIJ) Then
+        If (iter <= KXIJ) Then
             Open(unit=98,status='REPLACE',file='CONF.LVL',action='WRITE')
         Else
             Open(unit=98,status='UNKNOWN',POSITION='APPEND',file='CONF.LVL',action='WRITE')
@@ -2894,7 +2896,7 @@ Contains
         If (.not. Allocated(strcsave)) Allocate(strcsave(nconfs,Nlv))
         If (.not. Allocated(converged)) Allocate(converged(Nlv))
 
-        If (kWeights == 1) Then
+        If (KWeights == 1) Then
             Open(88,file='CONF.WGT',status='UNKNOWN')
             strfmt = '(I8,I6,F11.7)'
         End If
@@ -2928,7 +2930,7 @@ Contains
         If (mod(Ne,2) == 1) nspacesterm = 3
         Wsave = 0_dp
         Do j=1,Nlv
-            If (kWeights == 1) Then
+            If (KWeights == 1) Then
                 Write(88,'(A,I3)') 'Level #', j
                 Write(88,'(A25)') '========================='
                 Write(88,'(A25)') '      ID    IC     W     '
@@ -2941,10 +2943,10 @@ Contains
                 Do k=1,ndk
                     i=i+1
                     W(ic,j)=W(ic,j)+C(i)**2
-                    If (kWeights == 1) Write(88,strfmt) i, ic, C(i)**2
+                    If (KWeights == 1) Write(88,strfmt) i, ic, C(i)**2
                 End Do
             End Do
-            If (kWeights == 1) Write(88,'(A25)') '========================='
+            If (KWeights == 1) Write(88,'(A25)') '========================='
             k=0
 
             ! Calculate weights of non-relativistic configurations and store in array W2
@@ -3207,7 +3209,7 @@ Contains
         Close(97)
         Close(98)
         Close(99)
-        If (kWeights == 1) Close(88)
+        If (KWeights == 1) Close(88)
 
         ! Print the weights of each configuration
         n=(Nlv-1)/5+1

--- a/src/pconf.F90
+++ b/src/pconf.F90
@@ -62,15 +62,21 @@ Program pconf
     use formj2, only : FormJ
     Use str_fmt, Only : startTimer, stopTimer, FormattedTime
     Use env_var
-
+    
     Implicit None
+
+#ifdef USE_SCALAPACK
     External :: BLACS_PINFO, BLACS_EXIT
-    Integer   :: n, nnd, i, ierr, mype, npes, mpierr, threadLevel
-    Integer :: ncsf, nccj, max_ndcs, nbas
+#endif
+
+    Integer   :: n, i, ierr, mype, npes, mpierr, threadLevel
     Integer(kind=int64) :: start_time
-    Character(Len=255)  :: eValue, strfmt
+    Character(Len=255)  :: strfmt
     Character(Len=16)   :: timeStr
     Real(dp), Allocatable, Dimension(:) :: xj, xl, xs, ax_array
+
+    Type(MPI_Datatype) :: mpi_type_real
+    Type(MPI_Datatype) :: mpi_type2_real
 
     ! Initialize MPI
     Call MPI_Init_thread(MPI_THREAD_SINGLE, threadLevel, mpierr)
@@ -78,8 +84,11 @@ Program pconf
     Call MPI_Comm_rank(MPI_COMM_WORLD, mype, mpierr)
     ! Get number of processes
     Call MPI_Comm_size(MPI_COMM_WORLD, npes, mpierr)
+
+#ifdef USE_SCALAPACK
     Call BLACS_PINFO(mype,npes)
-    
+#endif
+
     Call startTimer(start_time)
     
     ! Set MPI type for type_real
@@ -139,7 +148,7 @@ Program pconf
     
     ! Davidson diagonalization
     Call Diag4(mype,npes) 
-    
+
     ! Print table of final energies
     If (mype==0) Call PrintEnergies
 
@@ -155,18 +164,18 @@ Program pconf
     ! Print table of final results and total computation time
     If (mype==0) Then
         Call PrintWeights
+        Close(11)
         
         Call stopTimer(start_time, timeStr)
-        write(*,'(2X,A)'), 'TIMING >>> Total computation time of conf was '// trim(timeStr)
-    End If
-
-    ! In rank 0, close-out unit 11
-    If (mype == 0) Then
-        Close(11)
+        write(*,'(2X,A)') 'TIMING >>> Total computation time of conf was '// trim(timeStr)
     End If
 
     ! All done: 
+#ifdef USE_SCALAPACK
     Call BLACS_EXIT(0)
+#else
+    Call MPI_Finalize(mpierr)
+#endif
 
 Contains
 
@@ -179,13 +188,13 @@ Contains
 
         Select Case(type_real)
         Case(sp)
-            strfmt = '(4X,"Program pconf v6.1 with single precision")'
+            strfmt = '(4X,"Program pconf v6.2 with single precision")'
         Case(dp)            
             Select Case(type2_real)
             Case(sp)
-                strfmt = '(4X,"Program pconf v6.1")'
+                strfmt = '(4X,"Program pconf v6.2")'
             Case(dp)
-                strfmt = '(4X,"Program pconf v6.1 with double precision for 2e integrals")'
+                strfmt = '(4X,"Program pconf v6.2 with double precision for 2e integrals")'
             End Select
         End Select
         
@@ -268,8 +277,10 @@ Contains
     End Subroutine Input
 
     Subroutine Init
+        Use utils, Only : DetermineRecordLength
+
         Implicit None
-        Integer  :: ic, n, j, imax, ni, ni2, kkj, llj, nnj, i, nj, nr, if, &
+        Integer  :: ic, n, j, imax, ni, ni2, kkj, llj, nnj, i, nj, nr, nf, &
                     ii, i1, n2, n1, l, nmin, jlj, i0, nlmax, err_stat
         Real(dp) :: d, c1, c2, z1
         Real(dp), Dimension(IP6)  :: p, q, p1, q1 
@@ -277,7 +288,7 @@ Contains
         Integer, Dimension(0:33)  ::  nnn ,jjj ,nqq, nnn1, qqq1, nnn2, qqq2
         Character(Len=1), Dimension(9) :: Let 
         Character(Len=1), Dimension(0:33):: lll, lll1, lll2
-        logical :: longbasis
+        Logical :: longbasis, success
         Integer, Dimension(4*IPs) :: IQN
         Real(dp), Dimension(IPs)  :: Qq1
         Character(Len=256) :: strfmt, err_msg
@@ -287,9 +298,26 @@ Contains
         Data Let/'s','p','d','f','g','h','i','k','l'/
 
         c1 = 0.01d0
-        mj = 2*dabs(Jm)+0.01d0
+        mj = Int(2*dabs(Jm)+0.01d0)
 
-        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*IPmr,iostat=err_stat,iomsg=err_msg)
+        nnn=0
+        jjj=0
+        nqq=0
+        nnn1=0
+        qqq1=0
+        nnn2=0
+        qqq2=0
+        lll=''
+        lll1=''
+        lll2=''
+
+        Call DetermineRecordLength(Mrec, success)
+        If (.not. success) Then
+            Write(*,*) 'ERROR: record length could not be determined'
+            Stop
+        End If
+
+        Open(12,file='CONF.DAT',status='OLD',access='DIRECT',recl=2*IP6*Mrec,iostat=err_stat,iomsg=err_msg)
         If (err_stat /= 0) Then
             strfmt='(/2X,"file CONF.DAT is absent"/)'
             Write( *,strfmt)
@@ -312,8 +340,8 @@ Contains
 
         Allocate(Nvc(Nc),Nc0(Nc),Nq(Nsp),Nip(Nsp))
         Allocate(Nrnrc(Nc))
-        Ns = pq(2)+c1
-        ii = pq(3)+c1
+        Ns = Int(pq(2)+c1)
+        ii = Int(pq(3)+c1)
         Rnuc=pq(13)
         dR_N=pq(16)
         
@@ -333,34 +361,34 @@ Contains
                 Jj(ni)=IQN(4*ni)
             End Do
         Else
-            if=20
+            nf=20
             Do ni=1,Ns
-                if=if+1
-                Nn(ni)=pq(if)+c1
-                if=if+1
-                Ll(ni)=pq(if)+c1
-                if=if+3
-                c2=dsign(c1,pq(if))
-                Kk(ni)=pq(if)+c2
-                if=if+1
-                c2=dsign(c1,pq(if))
-                Jj(ni)=pq(if)+c2
+                nf=nf+1
+                Nn(ni)=Int(pq(nf)+c1)
+                nf=nf+1
+                Ll(ni)=Int(pq(nf)+c1)
+                nf=nf+3
+                c2=dsign(c1,pq(nf))
+                Kk(ni)=Int(pq(nf)+c2)
+                nf=nf+1
+                c2=dsign(c1,pq(nf))
+                Jj(ni)=Int(pq(nf)+c2)
             End Do
         End If
 
         Nsu=0
         Do nj=1,Nsp
-            i=sign(1.d0,Qnl(nj))
+            i=Int(sign(1.d0,Qnl(nj)))
             d=dabs(Qnl(nj))+1.d-14
             d=10.0*d
-            nnj=d
+            nnj=Int(d)
             d=10.0d0*(d-nnj)
-            llj=d
+            llj=Int(d)
             jlj=2*llj+i
             kkj=-i*((jlj+1)/2)
             d=100.0d0*(d-llj)
-            Nq(nj)=d+0.1d0
-            Do ni=1,ns
+            Nq(nj)=Int(d+0.1d0)
+            Do ni=1,Ns
                 If (nnj == Nn(ni) .and. Kk(ni) == kkj) Then
                     Exit
                 Else If (ni == ns) Then
@@ -602,7 +630,7 @@ Contains
                 Iint1S(i)=ind
                 Rsig(i)=x
                 Dsig(i)=y
-                Esig(i)=z
+                Esig(i)=Real(z, kind=type2_real)
             End Do
         End Do
         xscr=10.d0
@@ -827,10 +855,12 @@ Contains
     
         Call calcMemStaticArrays
         Call FormattedMemSize(memStaticArrays, memStr)
-        Write(*,'(A,A,A)') 'calcMemReqs: Allocating static arrays will require at least ',Trim(memStr),' of memory per core. (These will not be deallocated)' 
+        Write(*,'(A,A,A)') 'calcMemReqs: Allocating static arrays will require at least ',Trim(memStr), &
+                            ' of memory per core. (These will not be deallocated)' 
 
         Call FormattedMemSize(memFormH, memStr)
-        Write(*,'(A,A,A)') 'calcMemReqs: Allocating arrays for FormH will require at least ',Trim(memStr),' of memory per core' 
+        Write(*,'(A,A,A)') 'calcMemReqs: Allocating arrays for FormH will require at least ',Trim(memStr), &
+                            ' of memory per core' 
         
         memEstimate = memFormH + memStaticArrays
     
@@ -917,7 +947,7 @@ Contains
         Else
             count = Ngint*2_int64
         End If
-        Call BroadcastD(Rint2, count, 0, 0, MPI_COMM_WORLD, mpierr)
+        Call BroadcastD(Rint2, count, 0, mpi_type2_real, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(Iint1, Nhint, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint2, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
         Call BroadcastI(Iint3, Ngint, 0, 0, MPI_COMM_WORLD, mpierr)
@@ -1081,7 +1111,7 @@ Contains
                                     Call Rspq_phase2(idet1, idet2, iSign, diff, iIndexes, jIndexes)
                                     If (Kdsig /= 0 .and. diff <= 2) E_k=Diag(kk)
                                     tt=Hmltn(idet1, iSign, diff, jIndexes(3), iIndexes(3), jIndexes(2), iIndexes(2))
-                                    If (tt /= 0) Then
+                                    If (tt /= 0_type_real) Then
                                         cntarray = cntarray + 1
                                         Call IVAccumulatorAdd(iva1, nn)
                                         Call IVAccumulatorAdd(iva2, kk)
@@ -1111,7 +1141,6 @@ Contains
                     Call MPI_RECV( cntarray, 3, MPI_INTEGER, MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, status, mpierr)
                     sender = status%MPI_SOURCE
              
-                    !If (devmode == 1) print*, cntarray(3), cntarray(1), sender
                     If (nnd + ndGrowBy <= Nd) Then
                         nnd = nnd + ndGrowBy
                         Call MPI_SEND( nnd, 1, MPI_INTEGER, sender, send_tag, MPI_COMM_WORLD, mpierr)
@@ -1135,11 +1164,12 @@ Contains
                         Call FormattedMemSize(maxmem, memStr2)
                         Call FormattedMemSize(NumH*(8+type_real), memStr3)
                         Write(counterStr,fmt='(I16)') NumH
-                        Write(*,'(2X,A,1X,I3,A)'), 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
+                        Write(*,'(2X,A,1X,I3,A)') 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
                                                     Trim(AdjustL(counterStr)) // ' elements'
-                        Write(*,'(4X,A)'), 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// trim(memStr2)//')'
+                        Write(*,'(4X,A)') 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// &
+                                            trim(memStr2)//')'
                         If (memTotalPerCPU /= 0 .and. statmem > memTotalPerCPU) Then
-                            Write(*,'(A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
+                            Write(*,'(A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
                                                     Trim(memTotStr2) ,' is available.'
                             Stop
                         End If
@@ -1158,22 +1188,23 @@ Contains
                         memEstimate = memEstimate + maxmem
                         Write(counterStr,fmt='(I16)') NumH
                         Call FormattedMemSize(mem, memStr)
-                        Write(*,'(2X,A,1X,I3,A)'), 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
+                        Write(*,'(2X,A,1X,I3,A)') 'FormH comparison stage:', (10-j)*10, '% done in '// trim(timeStr)// '; '// &
                                                     Trim(AdjustL(counterStr)) // ' elements'
-                        Write(*,'(4X,A)'), 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// trim(memStr2)//')'
-                        Write(*,'(A)'), 'SUMMARY - (total = '// trim(memStr) // ', static = ' // trim(memStr4) &
+                        Write(*,'(4X,A)') 'Memory: (HamiltonianTotal='// trim(memStr3)//', HamiltonianMaxMemPerCore='// &
+                                            trim(memStr2)//')'
+                        Write(*,'(A)') 'SUMMARY - (total = '// trim(memStr) // ', static = ' // trim(memStr4) &
                                             // ', davidson = ' // trim(memStr5) // ', Hamiltonian = ' // trim(memStr2) // ')'
                         If (memTotalPerCPU /= 0) Then
                             If (statmem > memTotalPerCPU) Then
-                                Write(*,'(A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
+                                Write(*,'(A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, but only ', &
                                                         Trim(memTotStr2) ,' is available.'
                                 Stop
                             Else If (statmem < memTotalPerCPU) Then
-                                Write(*,'(A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, and ' , &
+                                Write(*,'(A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, and ' , &
                                                         Trim(memTotStr2) ,' is available.'
                             End If
                         Else
-                            Write(*,'(2X,A,A,A,A)'), 'At least '// Trim(memTotStr), ' is required to finish conf, &
+                            Write(*,'(2X,A,A,A,A)') 'At least '// Trim(memTotStr), ' is required to finish conf, &
                                                         but available memory was not saved to environment'
                         End If
                         Exit
@@ -1264,7 +1295,7 @@ Contains
                     If (Kl /=3 .and. t == 0) numzero=numzero+1
                     If (counter1 == maxNumElementsPerCore .and. mod(n8,mesplit)==0) Then
                         Call stopTimer(s1, timeStr)
-                        Write(*,'(2X,A,1X,I3,A)'), 'FormH calculation stage:', j*10, '% done in '// trim(timeStr)
+                        Write(*,'(2X,A,1X,I3,A)') 'FormH calculation stage:', j*10, '% done in '// trim(timeStr)
                         j=j+1
                     End If
                 End Do
@@ -1279,7 +1310,7 @@ Contains
         End If
 
         ih8=size(Hamil%val, kind=int64)
-        ih4=ih8
+        ih4=Int(ih8, kind=int32)
         
         Call MPI_AllReduce(ih8, NumH, 1, MPI_INTEGER8, MPI_SUM, MPI_COMM_WORLD, mpierr)
         Call MPI_AllReduce(MPI_IN_PLACE, numzero, 1, MPI_INTEGER8, MPI_SUM, MPI_COMM_WORLD, mpierr)
@@ -1330,7 +1361,7 @@ Contains
         ! Stop timer and output computation time of FormH 
         If (mype == 0) Then
             Call stopTimer(stot, timeStr)
-            write(*,'(2X,A)'), 'TIMING >>> FormH took '// trim(timeStr) // ' to complete'
+            write(*,'(2X,A)') 'TIMING >>> FormH took '// trim(timeStr) // ' to complete'
         End If
 
         Return
@@ -1340,7 +1371,7 @@ Contains
         ! This function calculates the Hamiltonian matrix element between determinants idet1 and idet2
         Use determinants, Only : Rspq
         Use integrals, Only : Gint, Hint
-        Use formj2, Only : F_J0, F_J2
+        Use formj2, Only : F_J2
         Implicit None
         Integer, Allocatable, Dimension(:), Intent(InOut)   :: idet
         Integer, Intent(InOut)                              :: is, nf, i1, i2, j1, j2
@@ -1423,13 +1454,14 @@ Contains
         Implicit None
         Integer :: mpierr, mype
         Character(Len=16) :: memStr, memTotStr
+
         Call MPI_Barrier(MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(Nd0, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, mpierr)
         If (.not. Allocated(ArrB)) Allocate(ArrB(Nd,IPlv))
         If (.not. Allocated(Tk)) Allocate(Tk(Nlv))
         If (.not. Allocated(Tj)) Allocate(Tj(Nlv))
         If (.not. Allocated(P)) Allocate(P(2*Nlv,2*Nlv))
-        If (.not. Allocated(E)) Allocate(E(Nlv))
+        If (.not. Allocated(E)) Allocate(E(2*Nlv))
         If (.not. Allocated(Iconverge)) Allocate(Iconverge(Nlv))
         If (.not. Allocated(B1)) Allocate(B1(Nd))
         If (.not. Allocated(B2)) Allocate(B2(Nd))
@@ -1457,15 +1489,15 @@ Contains
             Call FormattedMemSize(memTotalPerCPU, memTotStr)
             If (memTotalPerCPU /= 0) Then
                 If (memEstimate > memTotalPerCPU) Then
-                    Write(*,'(A,A,A,A)'), 'At least '// Trim(memStr), ' is required to finish conf, but only ', &
+                    Write(*,'(A,A,A,A)') 'At least '// Trim(memStr), ' is required to finish conf, but only ', &
                                             Trim(memTotStr) ,' is available.'
                     Stop
                 Else If (memEstimate < memTotalPerCPU) Then
-                    Write(*,'(A,A,A,A)'), 'At least '// Trim(memStr), ' is required to finish conf, and ' , &
+                    Write(*,'(A,A,A,A)') 'At least '// Trim(memStr), ' is required to finish conf, and ' , &
                                             Trim(memTotStr) ,' is available.'
                 End If
             Else
-                Write(*,'(2X,A,A,A,A)'), 'At least '// Trim(memStr), ' is required to finish conf, &
+                Write(*,'(2X,A,A,A,A)') 'At least '// Trim(memStr), ' is required to finish conf, &
                                             but available memory was not saved to environment'
             End If
         End If   
@@ -1476,10 +1508,16 @@ Contains
         Use mpi_f08
         Use str_fmt, Only : startTimer, stopTimer, FormattedTime
         Use env_var
-        Implicit None
-        External :: INFOG2L, PDELGET, SSYEV, DSYEV, BLACS_GET, BLACS_GRIDINIT, BLACS_GRIDINFO, BLACS_GRIDEXIT, BLACS_EXIT, NUMROC, DESCINIT, PDELSET, PDSYEVD, PSSYEVD, PSELSET
 
-        Integer :: I, J, lwork, mype, npes, ifail, srcRow, srcCol
+        Implicit None
+        
+        External :: SSYEV, DSYEV
+#ifdef USE_SCALAPACK
+        External :: INFOG2L, PDELGET, BLACS_GET, BLACS_GRIDINIT, BLACS_GRIDINFO, BLACS_GRIDEXIT, &
+                    BLACS_EXIT, NUMROC, DESCINIT, PDELSET, PDSYEVD, PSSYEVD, PSELSET
+#endif
+
+        Integer :: I, J, lwork, mype, npes, ifail
         Integer :: NPROW, NPCOL, CONTEXT, MYROW, MYCOL, LIWORK, NROWSA, NCOLSA, NUMROC
         Integer(Kind=int64) :: s1, scalapackThreshold
         Integer(Kind=int64), Dimension(2) :: blacsGrid
@@ -1490,12 +1528,11 @@ Contains
         Integer, Allocatable, Dimension(:)     :: IWORK ! integer work array
         Real(type_real), Allocatable, Dimension(:)    :: W     ! double precision work array
         Real(type_real), Allocatable, Dimension(:,:)  :: A, Z
-        Character(len=48) :: blacsGridSpec
 
         If (mype == 0) Then
             ! At what point should we switch to the BLACS/ScaLAPACK algorithm?  The default
             ! value 10240 is just a guess and equates with an 800 MiB Z1:
-            scalapackThreshold = GetEnvInteger64("CONF_DIAG_INIT_APPROX_THRESHOLD", 10240)
+            scalapackThreshold = GetEnvInteger64("CONF_DIAG_INIT_APPROX_THRESHOLD", 10240_int64)
             isVerbose = GetEnvLogical("CONF_DIAG_INIT_APPROX_VERBOSE", .false.)
             shouldForceSerial = GetEnvLogical("CONF_DIAG_INIT_APPROX_FORCE_SERIAL", .false.)
             shouldForceScalapack = GetEnvLogical("CONF_DIAG_INIT_APPROX_FORCE_SCALAPACK", .false.)
@@ -1505,37 +1542,12 @@ Contains
         Call MPI_Bcast(isVerbose, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(shouldForceSerial, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, mpierr)
         Call MPI_Bcast(shouldForceScalapack, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, mpierr)
-        
+
         ! Start timer for initial diagonalization
         Call startTimer(s1)
 
-        ! If running in serial or size of initial approximation is below threshold, 
-        If (.not. shouldForceScalapack .and. (npes == 1 .or. Nd0 <= scalapackThreshold .or. shouldForceSerial)) Then
-            If (mype==0) Then
-                If (npes==1 .or. shouldForceSerial) Then
-                    Write(*,"(A)") "DiagInitApprox: ScaLAPACK not used, running serially"
-                Else
-                    Write(*,"(A,I12,A,I12)") "DiagInitApprox: ScaLAPACK not used, ", Nd0, " <= ", scalapackThreshold
-                End If
-            End If
-            Select Case(type_real)
-            Case(sp)
-                Call SSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
-            Case(dp)
-                Call DSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
-            End Select
-            lwork = Nint(realtmp(1))
-            Allocate(W(lwork))
-            If (mype==0 .and. isVerbose) Write(*,"(A,I12)") "DiagInitApprox: Work array allocated, real=", lwork
-            Select Case(type_real)
-            Case(sp)
-                Call SSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
-            Case(dp)
-                Call DSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
-            End Select
-            If (mype==0 .and. isVerbose) Write(*,"(A)") "DiagInitApprox: Eigenvalues and -vectors calculated"
-            Deallocate(W)
-        Else
+#ifdef USE_SCALAPACK
+        If (shouldForceScalapack .and. (npes > 1 .or. Nd0 > scalapackThreshold)) Then
             If (mype==0) Write(*,"(A,I5,A)") "DiagInitApprox: ScaLAPACK used, will distribute across ", npes, " cpus"
             NPROW=1
             NPCOL=npes
@@ -1544,20 +1556,23 @@ Contains
             CALL BLACS_GET(-1, 0, CONTEXT)
             CALL BLACS_GRIDINIT(CONTEXT, 'R', NPROW, NPCOL)
             CALL BLACS_GRIDINFO(CONTEXT, NPROW, NPCOL, MYROW, MYCOL)
-            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: BLACS grid init, rank ", mype, " -> ", MYROW,  ",", MYCOL
+            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: BLACS grid init, rank ", &
+                                                            mype, " -> ", MYROW,  ",", MYCOL
 
             ! Calculate the number of rows, NROWSA, and the number of columns, NCOLSA, for the local matrices A
             If (mype==0) Then
                 blacsGrid(1) = GetEnvInteger("CONF_DIAG_INIT_APPROX_BLACS_ROWS", Nd0)
                 blacsGrid(2) = GetEnvInteger("CONF_DIAG_INIT_APPROX_BLACS_COLS", 1)
-                If (isVerbose) Write(*,"(A,I5,A,I5,A)") "DiagInitApprox: BLACS grid will be ", blacsGrid(1), " rows by ", blacsGrid(2), " columns"
+                If (isVerbose) Write(*,"(A,I5,A,I5,A)") "DiagInitApprox: BLACS grid will be ", blacsGrid(1), &
+                                                        " rows by ", blacsGrid(2), " columns"
             End If
             Call MPI_Bcast(blacsGrid, 2, MPI_INTEGER8, 0, MPI_COMM_WORLD, mpierr)
             
             NROWSA = NUMROC(Nd0,blacsGrid(1),MYROW,0,NPROW)
             NCOLSA = NUMROC(Nd0,blacsGrid(2),MYCOL,0,NPCOL)
             ALLOCATE(A(NROWSA,NCOLSA), Z(NROWSA,NCOLSA))
-            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated local storage, rank ", mype, " -> ", NROWSA,  " x ", NCOLSA
+            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated local storage, rank ", &
+                                                            mype, " -> ", NROWSA,  " x ", NCOLSA
 
             ! Initialize array descriptors DESCA and DESCZ
             CALL DESCINIT(DESCA, Nd0, Nd0, blacsGrid(1), blacsGrid(2), 0, 0, CONTEXT, NROWSA, ifail)
@@ -1594,7 +1609,8 @@ Contains
             LWORK = realtmp(1)
             LIWORK = itmp(1)
             ALLOCATE(IWORK(LIWORK), W(LWORK))
-            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated work arrays, rank ", mype, " -> real=", LWORK,  ", integer=", LIWORK
+            If (isVerbose) Write(*,"(A,I5,A,I12,A,I12)") "DiagInitApprox: Allocated work arrays, rank ", mype, &
+                                                            " -> real=", LWORK,  ", integer=", LIWORK
 
             ! Compute the eigenvalues E1 and eigenvectors Z
             Select Case(type_real)
@@ -1621,12 +1637,47 @@ Contains
             ! Clean up
             Deallocate(IWORK, W, Z, A)
         End If
+#endif
+        If (.not. shouldForceScalapack .and. (npes <= 1 .or. Nd0 <= scalapackThreshold)) Then
+            If (mype==0) Then
+                If (npes==1 .or. shouldForceSerial) Then
+                    Write(*,"(A)") "DiagInitApprox: ScaLAPACK not used, running serially"
+                Else
+                    Write(*,"(A,I12,A,I12)") "DiagInitApprox: ScaLAPACK not used, ", Nd0, " <= ", scalapackThreshold
+                End If
+
+                Select Case(type_real)
+                Case(sp)
+                    Call SSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
+                Case(dp)
+                    Call DSYEV('V','U',Nd0,Z1,Nd0,E1,realtmp,-1,ifail)
+                End Select
+
+                lwork = Nint(realtmp(1))
+
+                Allocate(W(lwork))
+                If (isVerbose) Write(*,"(A,I12)") "DiagInitApprox: Work array allocated, real=", lwork
+                Select Case(type_real)
+                Case(sp)
+                    Call SSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
+                Case(dp)
+                    Call DSYEV('V','U',Nd0,Z1,Nd0,E1,W,lwork,ifail)
+                End Select
+                If (isVerbose) Write(*,"(A)") "DiagInitApprox: Eigenvalues and -vectors calculated"
+                Deallocate(W)
+            End If
+            Call MPI_Bcast(Z1, Nd0*Nd0, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, mpierr)
+            Call MPI_Bcast(E1, Nd0, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, mpierr)
+        End If
+
         If (mype==0) Then
             ! Stop timer and print time for initial diagonalization
             Call stopTimer(s1, timeStr)
-            Write(*,"(2X,A,A,A)"), "TIMING >>> Initial diagonalization took ", trim(timeStr), " to complete"
+            Write(*,"(2X,A,A,A)") "TIMING >>> Initial diagonalization took ", trim(timeStr), " to complete"
         End If
+
         Call MPI_Barrier(MPI_COMM_WORLD, mpierr)
+
     End Subroutine DiagInitApprox
 
     Subroutine Diag4(mype, npes)
@@ -1640,21 +1691,20 @@ Contains
         Implicit None
         External :: DSYEV, SSYEV
 
-        Integer  :: k1, k, i, n1, kx, i1, it, js, mype, npes, mpierr, ifail=0, lwork
+        Integer  :: k1, k, i, n1, kx, i1, it, mype, npes, mpierr, ifail, lwork
         Real(kind=type_real), Dimension(4) :: realtmp
         Real(kind=type_real), Allocatable, Dimension(:) :: W ! work array
         Integer(Kind=int64) :: start_time, s1
         Real(type_real)  :: crit, ax, x, xx, vmax
         Real(dp) :: cnx
         Character(Len=16) :: timeStr, iStr
-        Integer,  Allocatable, Dimension(:) :: Jn, Jk
-        Real(kind=type_real), Allocatable, Dimension(:) :: Jv
 
         ! Initialize parameters and arrays
         Iconverge = 0
         crit=1.d-6
         ax=1.d0
         cnx=1.d0
+        ifail=0
         If (.not. Allocated(ax_array)) Allocate(ax_array(Nlv))
 
         ! Start timer for Davidson procedure
@@ -1668,13 +1718,13 @@ Contains
         End If
 
         ! Construct initial approximation from Hamiltonian matrix
-        Call Init4(mype)
+        Call Init4(mype, mpi_type_real)
 
         ! Diagonalize the initial approximation 
         Call DiagInitApprox(mype, npes)
 
         ! Write initial approximation to file CONF.XIJ
-        Call FormB0(mype)
+        Call FormB0(mype, mpi_type_real)
         
         ! Set up work array for diagonalization of energy matrix P during iterative procedure
         If (mype == 0) Then
@@ -1687,15 +1737,6 @@ Contains
             End Select
             lwork = Nint(realtmp(1))
             Allocate(W(lwork))
-        End If
-
-        ! temporary solution for value of Jsq%ind1 changing during LAPACK ZSYEV subroutine
-        If (mype == 0) Then
-            js = size(Jsq%ind1)
-            Allocate(Jn(js),Jk(js),Jv(js))
-            Jn=Jsq%ind1
-            Jk=Jsq%ind2
-            Jv=Jsq%val
         End If
 
         ! Davidson loop:
@@ -1728,7 +1769,7 @@ Contains
                 End If
 
                 ! Formation of the left-upper block of the energy matrix P
-                Call Mxmpy(1, mype)
+                Call Mxmpy(1, mpi_type_real, mype)
                 If (mype==0) Then 
                     Call stopTimer(s1, timeStr)
                     Write(77,*) 'Mxmpy1 took ' // timeStr
@@ -1756,13 +1797,9 @@ Contains
                     Call stopTimer(s1, timeStr)
                     Write(77,*) 'Formation of Nlv additional probe vectors took' // timeStr
                 End If
+                
                 If (K_prj == 1) Then
-                    If (mype == 0) Then
-                        Jsq%ind1=Jn
-                        Jsq%ind2=Jk
-                        Jsq%val=Jv
-                    End If
-                    Call Prj_J(Nlv+1,Nlv,2*Nlv+1,1.d-5,mype)
+                    Call Prj_J(Nlv+1,Nlv,2*Nlv+1,1.d-5,mpi_type_real, mype)
                     If (mype == 0) Then
                         Call startTimer(s1)
                         Do i=Nlv+1,2*Nlv
@@ -1785,11 +1822,12 @@ Contains
                         Write(77,*) 'Orthogonalization of Nlv additional probe vectors took ' // timeStr
                     End If
                 End If
+                
                 Call MPI_Bcast(cnx, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, mpierr)
                 If (cnx > Crt4) Then
                     ! Formation of other three blocks of the matrix P:
                     Call startTimer(s1)
-                    Call Mxmpy(2, mype)
+                    Call Mxmpy(2, mpi_type_real, mype)
                     If (mype==0) Then
                         Call stopTimer(s1, timeStr)
                         Write(77,*) 'Mxmpy2 took ' // timeStr
@@ -1797,8 +1835,7 @@ Contains
                         Call FormP(2, vmax)
                         Call stopTimer(s1, timeStr)
                         Write(77,*) 'FormP2 took ' // timeStr
-                        ! >>>>> this block of code causes problem allocating xj, xl, xs arrays >>>>>
-                        ! >>>>>>>>>>>>>>>> if allocation occurs after this block >>>>>>>>>>>>>>>>>>>
+
                         ! Evaluation of Nlv eigenvectors:
                         Call startTimer(s1)
                         Select Case(type_real)
@@ -1807,7 +1844,6 @@ Contains
                         Case(dp)
                             Call DSYEV('V','U',n1,P,n1,E,W,lwork,ifail)
                         End Select
-                        ! <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                         Call stopTimer(s1, timeStr)
                         Write(77,*) 'Nlv eigenvectors evaluated in ' // timeStr
                         
@@ -1841,12 +1877,7 @@ Contains
                             ! Calculate J for each energy level
                             Do n=1,Nlv
                                 Call MPI_Bcast(ArrB(1:Nd,n), Nd, mpi_type_real, 0, MPI_COMM_WORLD, mpierr)
-                                If (mype == 0) Then
-                                    Jsq%ind1=Jn
-                                    Jsq%ind2=Jk
-                                    Jsq%val=Jv
-                                End If
-                                Call J_av(ArrB(1,n),Nd,Tj(n),ierr)  ! calculates expectation values for J^2
+                                Call J_av(ArrB(1,n),Nd,Tj(n),mpi_type_real,ierr)  ! calculates expectation values for J^2
                             End Do
                             If (mype == 0) Then
                                 Call FormB
@@ -1878,21 +1909,12 @@ Contains
             End If
         End Do
 
-        ! temporary solution for value of Jsq%ind1 changing during LAPACK ZSYEV subroutine
-        If (mype == 0) Then
-            Jsq%ind1=Jn
-            Jsq%ind2=Jk
-            Jsq%val=Jv
-            If (allocated(Jn)) Deallocate(Jn)
-            If (allocated(Jk)) Deallocate(Jk)
-            If (allocated(Jv)) Deallocate(Jv)
-        End If
         ! Write final eigenvalues and eigenvectors to file CONF.XIJ
         Call WriteFinalXIJ(mype)
 
         If (mype == 0) Then
             Call stopTimer(start_time, timeStr)
-            Write(*,'(2X,A)'), 'TIMING >>> Davidson procedure took '// trim(timeStr) // ' to complete'
+            Write(*,'(2X,A)') 'TIMING >>> Davidson procedure took '// trim(timeStr) // ' to complete'
             Close(77)
         End If
 
@@ -2005,13 +2027,13 @@ Contains
         Real(dp), Allocatable, Dimension(:)  :: C
         Real(dp), Allocatable, Dimension(:,:)  :: Weights, W2, Wsave
         Character(Len=512) :: strfmt, strconfig, strsp
-        Character(Len=64), Allocatable, Dimension(:,:) :: strcsave
+        Character(Len=512), Allocatable, Dimension(:,:) :: strcsave
         Character(Len=3) :: strc, strq
         Integer, Dimension(0:33)  ::  nnn, nqq 
         Character(Len=1), Dimension(9) :: Let 
         Character(Len=1), Dimension(0:33):: lll
         Type WeightTable
-            Character(Len=64), Allocatable, Dimension(:) :: strconfs, strconfsave
+            Character(Len=512), Allocatable, Dimension(:) :: strconfs, strconfsave
             Integer, Allocatable, Dimension(:) :: nconfs, nconfsave
             Real(dp), Allocatable, Dimension(:) :: wgt, wgtsave
         End Type WeightTable
@@ -2102,7 +2124,8 @@ Contains
                     Else
                         strq = ''
                     End If
-                    strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
+                    strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // &
+                                Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
                 End Do
                 strcsave(k,j) = strconfig
             End Do
@@ -2151,8 +2174,10 @@ Contains
                     wgtconfs%strconfs(k) = strcsave(i,j)
                     k = k + 1
                 End If
-                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
-                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
+                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
+                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
                 wsum = wsum + Wsave(i,j)
             End Do
             Write(98,'(A)') '_______'
@@ -2207,16 +2232,13 @@ Contains
         Implicit None
         Integer :: i, n, ierr, mype, mpierr
 
-        !If (K_prj == 1) Then
-        !    Call Prj_J(1,Nlv,Nlv+1,1.d-8,mype)
-        !End If
         If (mype == 0) Then
             open(unit=17,file='CONF.XIJ',status='OLD',form='UNFORMATTED')
         End If
         
         Do n=1,Nlv
             Call MPI_Bcast(ArrB(1:Nd,n), Nd, mpi_type_real, 0, MPI_COMM_WORLD, mpierr)
-            Call J_av(ArrB(1,n),Nd,Tj(n),ierr)  ! calculates expectation values for J^2
+            Call J_av(ArrB(1,n),Nd,Tj(n),mpi_type_real,ierr)  ! calculates expectation values for J^2
             If (mype==0) Then
                 write(17) Tk(n),Tj(n),Nd,(ArrB(i,n),i=1,Nd)
             End If
@@ -2366,14 +2388,14 @@ Contains
 
                     If (nnc == nccnt .and. nnc /= ncsplit*10) Then
                         Call stopTimer(s1, timeStr)
-                        If (moreTimers == .true.) Write(*,'(2X,A,1X,I3,A)'), 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
+                        If (moreTimers) Write(*,'(2X,A,1X,I3,A)') 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
                         j=j-1
                         nccnt = nccnt + ncsplit
                     End If
 
                     If (num_done == npes-1) Then
                         Call stopTimer(s1, timeStr)
-                        If (moreTimers == .true.) Write(*,'(2X,A,1X,I3,A)'), 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
+                        If (moreTimers) Write(*,'(2X,A,1X,I3,A)') 'lsj:', (10-j)*10, '% done in '// trim(timeStr)
                         Exit
                     End If
                 End Do
@@ -2835,7 +2857,8 @@ Contains
     Subroutine PrintWeights
         ! This subroutine prints the weights of configurations
         Implicit None
-        Integer :: j, k, j1, j2, j3, ic, i, ii, i1, l, n0, n1, n2, ni, nk, ndk, m1, nspaces, nspacesg, nconfs, cnt, nspacesterm, maxlenconfig, num_blanks, num_blanks2
+        Integer :: j, k, j1, j2, j3, ic, i, i1, l, n0, n1, n2, ni, nk, ndk, m1, nspaces, nspacesg, &
+                    nconfs, cnt, nspacesterm, maxlenconfig, num_blanks, num_blanks2
         Real(dp) :: wsum, gfactor, ax_crit, j_crit
         Integer, Allocatable, Dimension(:,:) :: Wpsave
         Real(dp), Allocatable, Dimension(:)  :: C
@@ -2972,7 +2995,8 @@ Contains
                     If (strconfig == '') Then
                         strconfig = Trim(AdjustL(strc)) // Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
                     Else
-                        strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
+                        strconfig = Trim(AdjustL(strconfig)) // ' ' // Trim(AdjustL(strc)) // &
+                                    Trim(AdjustL(lll(i))) // Trim(AdjustL(strq))
                     End If
                 End Do
                 strcsave(k,j) = strconfig
@@ -3032,25 +3056,31 @@ Contains
                 ! Write column names if first iteration
                 If (j == 1) Then
                     num_blanks = max(0, maxlenconfig-3)
-                    Write(99, '(A)') '  n' // '  ' // repeat(' ', num_blanks) // 'conf  term     E_n (a.u.)   DEL (cm^-1)     S     L     J     gf     conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
+                    Write(99, '(A)') '  n' // '  ' // repeat(' ', num_blanks) // 'conf  term     E_n (a.u.)   DEL (cm^-1) &
+                                        S     L     J     gf     conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
                 End If
                 ! If main configuration has weight of less than 0.7, we have to include a secondary configuration
                 num_blanks = max(0, maxlenconfig-len_trim(strcsave(1,j))+1)
                 If (Wsave(1,j) < 0.7) Then
                     num_blanks2 = max(0, maxlenconfig-len_trim(strcsave(2,j))+1)
                     strfmt = '(I3,3X,A,A,1X,f14.8,f14.1,2X,f4.2,2x,f4.2,2x,f4.2,2x,A,4x,f4.1,"%",5X,A,2X,A,3X,f5.1,"%")'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), Tk(j), (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, Wsave(1,j)*100, strconverged, repeat(' ', num_blanks2) // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), Tk(j), &
+                                     (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, Wsave(1,j)*100, strconverged, &
+                                     repeat(' ', num_blanks2) // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
                 ! Else we include only the main configuration
                 Else
                     strfmt = '(I3,3X,A,A,1X,f14.8,f14.1,2X,f4.2,2x,f4.2,2x,f4.2,2x,A,4x,f5.1,"%",5X,A)'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), Tk(j), (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, maxval(W2(1:Nnr,j))*100, strconverged
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), AdjustR(strterm), &
+                                        Tk(j), (Tk(1)-Tk(j))*2*DPRy, Xs(j), Xl(j), Tj(j), strgf, maxval(W2(1:Nnr,j))*100, &
+                                        strconverged
                 End If
             ! If L, S, J is not needed
             Else
                 ! Write column names if first iteration
                 If (j == 1) Then
                     num_blanks = max(0, maxlenconfig-3)
-                    Write(99, '(A)') '  n ' // '  ' // repeat(' ', num_blanks) // 'conf       J         E_n (a.u.)   DEL (cm^-1)    conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
+                    Write(99, '(A)') '  n ' // '  ' // repeat(' ', num_blanks) // 'conf       J         E_n (a.u.)  &
+                                         DEL (cm^-1)    conf%  converged'// repeat(' ', num_blanks) // ' conf2  conf2%'
                 End If
 
                 ! If main configuration has weight of less than 0.7, we have to include a secondary configuration
@@ -3058,11 +3088,14 @@ Contains
                 If (Wsave(1,j) < 0.7) Then
                     num_blanks2 = max(0, maxlenconfig-len_trim(strcsave(2,j))+1)
                     strfmt = '(I3,4X,A,4X,f4.2,5x,f14.8,f14.1,3X,f4.1,"%",,5X,A,2X,A,3X,f5.1,"%")'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), (Tk(1)-Tk(j))*2*DPRy, Wsave(1,j)*100, strconverged, repeat(' ', num_blanks2) // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), &
+                                        (Tk(1)-Tk(j))*2*DPRy, Wsave(1,j)*100, strconverged, repeat(' ', num_blanks2) &
+                                        // Trim(AdjustL(strcsave(2,j))), Wsave(2,j)*100
                 ! Else we include only the main configuration
                 Else
                     strfmt = '(I3,4X,A,4X,f4.2,5x,f14.8,f14.1,3X,f5.1,"%",5X,A)'
-                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), (Tk(1)-Tk(j))*2*DPRy, maxval(W2(1:Nnr,j))*100, strconverged
+                    Write(99,strfmt) j, repeat(' ', num_blanks) // Trim(AdjustL(strcsave(1,j))), Tj(j), Tk(j), &
+                                        (Tk(1)-Tk(j))*2*DPRy, maxval(W2(1:Nnr,j))*100, strconverged
                 End If
             End If 
         End Do
@@ -3099,8 +3132,10 @@ Contains
                     wgtconfs%strconfs(k) = strcsave(i,j)
                     k = k + 1
                 End If
-                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
-                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
+                wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%nconfs(findloc(wgtconfs%strconfs, strcsave(i,j))) + 1  
+                wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) = &
+                    wgtconfs%wgt(findloc(wgtconfs%strconfs, strcsave(i,j))) + Wsave(i,j)
                 wsum = wsum + Wsave(i,j)
             End Do
             Write(98,'(A)') '_______'
@@ -3197,9 +3232,16 @@ Contains
             End Do
             Write(11,strfmt) (st1,i=j1,j3)
         End Do
-        Deallocate(C, W, W2, Wsave, Wpsave, strcsave, Ndc, Tk, Tj, ArrB)
-        Close(11)
-        
+
+        If (Allocated(W)) Deallocate(W)
+        If (Allocated(W2)) Deallocate(W2)
+        If (Allocated(Wsave)) Deallocate(Wsave)
+        If (Allocated(Wpsave)) Deallocate(Wpsave)
+        If (Allocated(strcsave)) Deallocate(strcsave)
+        If (Allocated(Ndc)) Deallocate(Ndc)
+        If (Allocated(Tk)) Deallocate(Tk)
+        If (Allocated(ArrB)) Deallocate(ArrB)
+                
     End Subroutine PrintWeights
 
     Character(Len=6) Function term(L, S, J)

--- a/src/pdtm.f90
+++ b/src/pdtm.f90
@@ -1,5 +1,6 @@
 Program pdtm 
     Use params
+    Use conf_variables, Only : B1, B2
     Use mpi_f08
     Use determinants, Only : Dinit, Jterm
     Use str_fmt, Only : startTimer, stopTimer, FormattedTime

--- a/src/pol.f90
+++ b/src/pol.f90
@@ -40,7 +40,7 @@ Program pol
     !         General convention: GLOBAL VARIABLES     |||
     !              ARE CAPITALISED                     |||
     ! ||||||||||||||||||||||||||||||||||||||||||||||||||||
-    Use params, ipmr1 => IPmr, IP1conf => IP1
+    Use params, IP1conf => IP1
     Use determinants, Only : Dinit, Jterm
     Use str_fmt, Only : startTimer, stopTimer
 
@@ -171,7 +171,7 @@ Program pol
     Close(unit=11) ! Close POL.RES
     Close(unit=99) ! Close POL_E1.RES
     Call stopTimer(start_time, timeStr)
-    Write(*,'(2X,A)'), 'TIMING >>> Total computation time of pol was '// trim(timeStr)
+    Write(*,'(2X,A)') 'TIMING >>> Total computation time of pol was '// trim(timeStr)
     
 Contains
 
@@ -286,7 +286,7 @@ Contains
         equals_in_str = .true.
         Do While (equals_in_str)
             Read(88, '(A)', iostat=err_stat) line
-            If (index(string=line, substring="=") == 0 .or. err_stat) Then
+            If (index(string=line, substring="=") == 0 .or. err_stat /= 0) Then
                 equals_in_str = .false.
             Else
                 index_equals = index(string=line, substring="=")
@@ -360,7 +360,8 @@ Contains
         If (nrange > 0) Then
             Write(*,'(I2,A)') nrange, ' wavelength intervals with step size found:'
             Do i=1,nrange
-                Write(*,'(A,F11.3,A,F11.3,A,F11.4,A)')' lambda=',xlamb1s(i),' nm to ',xlamb2s(i),' nm in steps of ',xlambsteps(i), ' nm'
+                Write(*,'(A,F11.3,A,F11.3,A,F11.4,A)')' lambda=',xlamb1s(i),' nm to ',xlamb2s(i), &
+                                                        ' nm in steps of ',xlambsteps(i), ' nm'
             End Do
         Else
             Write(*,'(A)') 'ERROR: no wavelengths were specified'
@@ -389,7 +390,7 @@ Contains
 
         Call ReadPolIn
 
-        strfmt = '(1X,70("-"),/1X,"Program pol v1.0")'
+        strfmt = '(1X,70("-"),/1X,"Program pol v1.1")'
         Write( 6,strfmt) 
         Write(11,strfmt) 
 
@@ -864,7 +865,7 @@ Contains
         If (.not. Allocated(Hamil%t)) Allocate(Hamil%t(NumH))
         cnt=0
         Do i8=1,NumH
-            Read(15), Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
+            Read(15) Hamil%k(i8), Hamil%n(i8), Hamil%t(i8)
             if (Hamil%n(i8) == Nd + 1) then
                 NumH=cnt
                 print*,'For Nd=',Nd,', NumH=', NumH
@@ -1003,7 +1004,7 @@ Contains
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Z matrix calculated in '// trim(timeStr)// '.'
         
         strfmt = '(3X," NumH =",I10,";  Hmin =",F12.6/)'
         Write(*,strfmt) NumH,Hmin
@@ -1036,14 +1037,14 @@ Contains
         Call system_clock(end2)
         ttime2=Real((end2-start2)/clock_rate)
         Call FormattedTime(ttime2, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: Zspsv in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: Zspsv in '// trim(timeStr)// '.'
 
         X1= 0.d0
         X1(1:Ntr)= Real(XX1(1:Ntr), kind=dp)
         Call system_clock(end1)
         ttime=Real((end1-start1)/clock_rate)
         Call FormattedTime(ttime, timeStr)
-        Write(*,'(2X,A)'), 'SolEq1: decomp in '// trim(timeStr)// '.'
+        Write(*,'(2X,A)') 'SolEq1: decomp in '// trim(timeStr)// '.'
         
         If (sign == 1) Then
             Open(unit=16,file='POL_p.XIJ',status='UNKNOWN',form='UNFORMATTED')

--- a/src/pol.f90
+++ b/src/pol.f90
@@ -40,7 +40,7 @@ Program pol
     !         General convention: GLOBAL VARIABLES     |||
     !              ARE CAPITALISED                     |||
     ! ||||||||||||||||||||||||||||||||||||||||||||||||||||
-    Use params, IP1conf => IP1
+    Use params
     Use determinants, Only : Dinit, Jterm
     Use str_fmt, Only : startTimer, stopTimer
 

--- a/src/sort.f90
+++ b/src/sort.f90
@@ -16,7 +16,7 @@ program sort
 
     ! End program timer
     call stopTimer(start_time, time_str)
-    write(*,'(2X,A)'), 'TIMING >>> Total computation time of sort was '// trim(time_str)
+    write(*,'(2X,A)') 'TIMING >>> Total computation time of sort was '// trim(time_str)
 
 contains
 
@@ -57,7 +57,7 @@ contains
     
         ! Sort matrix elements
         call startTimer(start_time2)
-        call quicksort_matrix(mat%indices1, mat%indices2, mat%values, 1, num_total_elements)
+        call quicksort_matrix(mat%indices1, mat%indices2, mat%values, 1_int64, num_total_elements)
         call stopTimer(start_time2, time_str2)
         print*, trim(adjustl(filename)) // ' sorted in ' // trim(adjustl(time_str2))
         

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -1,31 +1,74 @@
-module utils
+Module utils
     ! This module contains general utility functions and subroutines for the pCI software package
 
-    implicit none
+    Implicit None
 
-    private
+    Private
 
-    public :: CountSubstr
+    Public :: CountSubstr, DetermineRecordLength
 
-contains
+Contains
 
-    function CountSubstr(str, substr) result(count)
+    Function CountSubstr(str, substr) Result(count)
         ! This function counts the number of occurences of a substring in a string
-        implicit none
+        Implicit None
 
-        integer :: i, position, count
-        character(len=*), intent(in) :: str
-        character(len=*), intent(in) :: substr
+        Integer :: i, position, count
+        Character(Len=*), Intent(In) :: str
+        Character(Len=*), Intent(In) :: substr
 
         count = 0
         i = 1
-        do 
+        Do 
             position = index(str(i:), substr)
-            if (position == 0) return
+            If (position == 0) Return
             count = count + 1
             i = i + position + len(substr) - 1
-        end do
+        End Do
 
-    end function CountSubstr
+    End Function CountSubstr
 
-end module utils
+    Subroutine DetermineRecordLength(lrec, success)
+        ! Determines the minimum usable record length for direct access files 
+        Integer, intent(Out) :: lrec
+        Logical, intent(Out) :: success
+
+        Integer :: irecl, err_stat
+        Character(Len=8) :: test_data, read_data
+
+        test_data = 'abcdefgh'
+        irecl = 1
+        success = .false.
+
+        Do
+            ! Open a file to test writing and reading test_data with increasing record length
+            Open(unit=10, file='test.tmp', status='UNKNOWN', access='DIRECT', recl=irecl, iostat=err_stat)
+            If (err_stat /= 0) then
+                Exit
+            End If
+
+            ! Try writing test_data
+            Write(10, rec=1, iostat=err_stat) test_data
+            If (err_stat /= 0) Then
+                Close(unit=10, status='DELETE')
+                irecl = irecl + 1
+                Cycle
+            End If
+
+            ! Try reading read_data
+            Read(10, rec=1, iostat=err_stat) read_data
+            Close(unit=10, status='DELETE')
+            If (err_stat == 0 .and. read_data == test_data) Then
+                success = .true.
+                lrec = irecl
+                Exit
+            End If
+        End Do
+    
+        If (.not. success) Then
+            lrec = -1
+        End If
+
+    End Subroutine DetermineRecordLength
+
+End Module utils

--- a/src/wigner.f90
+++ b/src/wigner.f90
@@ -1,300 +1,338 @@
 Module wigner
 
-    Use params 
+    Use, Intrinsic :: iso_fortran_env, Only : dp => real64
 
     Implicit None
 
     Private
-
-    Real(dp), Public :: ALL
     
-    Public :: FJ3, FJ6, FJ9, DELFJ, NGFJ, OBME, PORAD
+    Public :: FJ3, FJ6, FJ9, DELFJ, NGFJ, swap, sortArray
 
   Contains
 
-    Real(dp) Function FJ3(A1,A2,A3,A4,A5,A6)
-      Implicit None
+    Real(dp) Function FJ3(a1, a2, a3, a4, a5, a6)
+        Implicit None
 
-      Integer                  :: K, L, KU, KM
-      Real(dp)                 :: A1, A2, A3, A4, A5, A6, EPS, UN
-      Real(dp), Dimension(9)   :: X
-      Integer, Dimension(9)    :: LU, LI
-      Real(dp), Dimension(3)   :: Y, Z
-      Integer, Dimension(3)    :: MA, NA
+        Real(dp), Intent(In) :: a1, a2, a3, a4, a5, a6
 
-      IF(dABS(A4+A5+A6)-0.0001_dp) 20,2,2
-20    X(1)=A1+A2-A3
-      X(2)=A1-A2+A3
-      X(3)=-A1+A2+A3
-      X(4)=A1+A4
-      X(5)=A1-A4
-      X(6)=A2+A5
-      X(7)=A2-A5
-      X(8)=A3+A6
-      X(9)=A3-A6
-      EPS=0.0001_dp
-      X=ANINT(X*100.0)/100.0
-      DO 1 K=1,9
-      IF(X(K)) 2,3,3
-3     LU(K)=X(K)
-      IF(dABS(LU(K)-X(K))-EPS) 1,2,2
-1     CONTINUE
-      GO TO  4
-2     FJ3=0._dp
-      GO TO 5
-4     Y(1)=A1+A2-A3
-      Y(2)=A1-A4
-      Y(3)=A2+A5
-      Y=ANINT(Y*100.0)/100.0
-      Z(1)=0._dp
-      Z(2)=-A3+A2-A4
-      Z(3)=-A3+A1+A5
-      Z=ANINT(Z*100.0)/100.0
-      DO 6 K=1,3
-      MA(K)=Y(K)
-      NA(K)=Z(K)
-      IF(dABS(MA(K)-Y(K))-EPS) 7,2,2
-7     IF(dABS(NA(K)-Z(K))-EPS) 6,2,2
-6     CONTINUE
-      CALL PORAD(MA,3)
-      CALL PORAD(NA,3)
-      IF(MA(1)) 2,8,8
-8     IF(MA(1)-NA(3)) 2,9,9
-9     LI(1)=A1+A2+A3+1._dp
-      DO 10 K=1,2
-      LI(K+1)=MA(K+1)-MA(1)
-      LI(K+3)=MA(K+1)-MA(1)
-      LI(K+5)=NA(3)-NA(K)
-10    LI(K+7)=NA(3)-NA(K)
-      CALL PORAD(LU,9)
-      CALL PORAD(LI,9)
-      ALL=0._dp
-      DO 11 K=1,9
-      IF(LU(K)-LI(K)) 12,11,13
-12    CALL NGFJ(-1,LU(K),LI(K))
-      GO TO 11
-13    CALL NGFJ(1,LI(K),LU(K))
-11    CONTINUE
-      FJ3=0._dp
-      UN=ALL/2
-      KM=MA(1)-NA(3)+1
-      DO 14 KU=1,KM
-      K=NA(3)+KU-1
-      ALL=0._dp
-      CALL NGFJ(-1,0,MA(1)-K)
-      CALL NGFJ(-1,MA(2)-MA(1),MA(2)-K)
-      CALL NGFJ(-1,MA(3)-MA(1),MA(3)-K)
-      CALL NGFJ(-1,0,K-NA(3))
-      CALL NGFJ(-1,NA(3)-NA(1),K-NA(1))
-      CALL NGFJ(-1,NA(3)-NA(2),K-NA(2))
-      L=K+A1-A2-A6
-14    FJ3=FJ3+(-1)**L*dEXP(ALL)
-      FJ3=dEXP(UN)*FJ3
-5     CONTINUE
-      RETURN
+        Integer :: k, l, ku, km
+        Real(dp) :: eps, un, all
+        Real(dp), Dimension(9) :: x
+        Integer, Dimension(9) :: lu, li
+        Real(dp), Dimension(3) :: y, z
+        Integer, Dimension(3) :: ma, na
+
+        eps = 0.0001_dp
+
+        If (dabs(a4 + a5 + a6) >= eps) Then
+            fj3 = 0_dp
+            Return
+        End If
+
+        x(1) = a1 + a2 - a3
+        x(2) = a1 - a2 + a3
+        x(3) = -a1 + a2 + a3
+        x(4) = a1 + a4
+        x(5) = a1 - a4
+        x(6) = a2 + a5
+        x(7) = a2 - a5
+        x(8) = a3 + a6
+        x(9) = a3 - a6
+        x = Anint(x * 100_dp) / 100_dp
+        
+        Do k = 1, 9
+            If (x(k) < 0_dp) Then
+                fj3 = 0_dp
+                Return
+            Else
+                lu(k) = Int(x(k))
+                If (dabs(lu(k) - x(k)) >= eps) Then
+                    fj3 = 0.0_dp
+                    Return
+                End If
+            End If
+        End Do
+        
+        y(1) = a1 + a2 - a3
+        y(2) = a1 - a4
+        y(3) = a2 + a5
+        y = Anint(y * 100_dp) / 100_dp
+        
+        z(1) = 0_dp
+        z(2) = -a3 + a2 - a4
+        z(3) = -a3 + a1 + a5
+        z = Anint(z * 100_dp) / 100_dp
+        
+        DO k = 1, 3
+            ma(k) = Int(y(k))
+            na(k) = Int(z(k))
+            If (dabs(ma(k) - y(k)) >= eps .or. dabs(na(k) - z(k)) >= eps) Then
+                fj3 = 0.0_dp
+                Return
+            End If
+        End Do
+        
+        Call sortArray(ma, 3)
+        Call sortArray(na, 3)
+        
+        If (ma(1) < 0 .or. ma(1) < na(3)) Then
+            fj3 = 0.0_dp
+            Return
+        End If
+        
+        li(1) = a1 + a2 + a3 + 1_dp
+        Do k = 1, 2
+            li(k + 1) = ma(k + 1) - ma(1)
+            li(k + 3) = ma(k + 1) - ma(1)
+            li(k + 5) = na(3) - na(k)
+            li(k + 7) = na(3) - na(k)
+        End Do
+        
+        Call sortArray(lu, 9)
+        Call sortArray(li, 9)
+        
+        all = 0_dp
+        Do k = 1, 9
+            If (lu(k) /= li(k)) Then
+                If (lu(k) > li(k)) Then
+                    Call NGFJ(1, li(k), lu(k), all)
+                Else
+                    Call NGFJ(-1, lu(k), li(k), all)
+                End If
+            End If
+        End Do
+        
+        un = all / 2_dp
+        km = ma(1) - na(3) + 1
+
+        fj3 = 0.0_dp
+        Do ku = 1, km
+            k = na(3) + ku - 1
+            all = 0.0_dp
+            Call NGFJ(-1, 0, ma(1) - k, all)
+            Call NGFJ(-1, ma(2) - ma(1), ma(2) - k, all)
+            Call NGFJ(-1, ma(3) - ma(1), ma(3) - k, all)
+            Call NGFJ(-1, 0, k - na(3), all)
+            Call NGFJ(-1, na(3) - na(1), k - na(1), all)
+            Call NGFJ(-1, na(3) - na(2), k - na(2), all)
+            l = k + a1 - a2 - a6
+            fj3 = fj3 + (-1)**l * dexp(all)
+        End Do
+        
+        fj3 = dexp(un) * fj3
+
     End Function FJ3
 
-    Real(dp) Function FJ6(A1,A2,A3,A4,A5,A6)
-      Implicit None
+    Real(dp) Function FJ6(a1, a2, a3, a4, a5, a6)
+        Implicit None
 
-      Integer                 :: K, L, KM
-      Real(dp)                :: EPS, A1, A2, A3, A4, A5, A6
-      Real(dp)                :: X1, X2, X3, X4, Y1, Y2, Y3, UN
-      Integer, Dimension(4)   :: MA
-      Integer, Dimension(3)   :: NA
-      Real(dp), Dimension(12) :: X
-      Integer, Dimension(13)  :: LU, LI
+        Real(dp), Intent(In) :: a1, a2, a3, a4, a5, a6
 
-      X1=A1+A2+A3
-      X2=A1+A5+A6
-      X3=A4+A2+A6
-      X4=A4+A5+A3
-      Y1=A1+A2+A4+A5
-      Y2=A2+A3+A5+A6
-      Y3=A3+A1+A6+A4
-      EPS=0.0001_dp
-      MA(1)=X1+EPS
-      MA(2)=X2+EPS
-      MA(3)=X3+EPS
-      MA(4)=X4+EPS
-      NA(1)=Y1+EPS
-      NA(2)=Y2+EPS
-      NA(3)=Y3+EPS
-      IF(dABS(MA(1)-X1)-EPS) 20,12,12
-20    IF(dABS(MA(2)-X2)-EPS) 21,12,12
-21    IF(dABS(MA(3)-X3)-EPS) 22,12,12
-22    IF(dABS(MA(4)-X4)-EPS) 23,12,12
-23    IF(dABS(NA(1)-Y1)-EPS) 24,12,12
-24    IF(dABS(NA(2)-Y2)-EPS) 25,12,12
-25    IF(dABS(NA(3)-Y3)-EPS) 26,12,12
-26    GO TO 10
-12    FJ6=0._dp
-      GO TO 11
-10    CALL PORAD(MA,4)
-      CALL PORAD(NA,3)
-      IF(MA(4)-NA(1)) 27,27,12
-27    X(1)=A1+A2-A3
-      X(2)=A1-A2+A3
-      X(3)=-A1+A2+A3
-      X(4)=A1+A5-A6
-      X(5)=A1-A5+A6
-      X(6)=-A1+A5+A6
-      X(7)=A4+A2-A6
-      X(8)=A4-A2+A6
-      X(9)=-A4+A2+A6
-      X(10)=A4+A5-A3
-      X(11)=A4-A5+A3
-      X(12)=-A4+A5+A3
-      X=ANINT(X*100.0)/100.0
-      ALL=0._dp
-      DO 1 K=1,12
-      IF(X(K)) 12,1,1
-1     LU(K)=X(K)+EPS
-      LU(13)=MA(4)+1
-      DO 2 K=1,3
-      LI(K)=MA(K)+1
-      LI(3+K)=MA(4)-MA(K)
-2     LI(6+K)=LI(3+K)
-      DO 3 K=1,2
-      LI(9+K)=NA(K+1)-NA(1)
-3     LI(11+K)=LI(9+K)
-      CALL PORAD(LU,13)
-      CALL PORAD(LI,13)
-      ALL=0._dp
-      DO 4 K=1,13
-      IF(LU(K)-LI(K)) 5,4,7
-5     CALL NGFJ(-1,LU(K),LI(K))
-      GO  TO  4
-7     CALL NGFJ(1,LI(K),LU(K))
-4     CONTINUE
-      FJ6=0._dp
-      UN=ALL/2
-      KM=NA(1)-MA(4)+1
-      DO 6 L=1,KM
-      K=MA(4)+L-1
-      ALL=0._dp
-      CALL NGFJ(1,MA(4)+1,K+1)
-      CALL NGFJ(-1,MA(4)-MA(1),K-MA(1))
-      CALL NGFJ(-1,MA(4)-MA(2),K-MA(2))
-      CALL NGFJ(-1,MA(4)-MA(3),K-MA(3))
-      CALL NGFJ(-1,0,K-MA(4))
-      CALL NGFJ(-1,0,NA(1)-K)
-      CALL NGFJ(-1,NA(2)-NA(1),NA(2)-K)
-      CALL NGFJ(-1,NA(3)-NA(1),NA(3)-K)
-      FJ6=FJ6+(-1)**K*dEXP(ALL)
-6     CONTINUE
-      FJ6=dEXP(UN)*FJ6
-11    RETURN
+        Integer :: k, l, km
+        Real(dp) :: eps, x1, x2, x3, x4, y1, y2, y3, un, all
+        Integer, Dimension(4) :: ma
+        Integer, Dimension(3) :: na
+        Real(dp), Dimension(12) :: x
+        Integer, Dimension(13) :: lu, li
+
+        fj6 = 0.0_dp
+
+        x1 = a1 + a2 + a3
+        x2 = a1 + a5 + a6
+        x3 = a4 + a2 + a6
+        x4 = a4 + a5 + a3
+        y1 = a1 + a2 + a4 + a5
+        y2 = a2 + a3 + a5 + a6
+        y3 = a3 + a1 + a6 + a4
+
+        eps = 0.0001_dp
+        ma(1) = x1 + eps
+        ma(2) = x2 + eps
+        ma(3) = x3 + eps
+        ma(4) = x4 + eps
+        na(1) = y1 + eps
+        na(2) = y2 + eps
+        na(3) = y3 + eps
+
+        If (Any(dabs(ma - [x1, x2, x3, x4]) >= eps) .or. &
+            Any(dabs(na - [y1, y2, y3]) >= eps)) Return
+
+        Call sortArray(ma, 4)
+        Call sortArray(na, 3)
+
+        If (ma(4) > na(1)) Return
+        
+        x(1) = a1 + a2 - a3
+        x(2) = a1 - a2 + a3
+        x(3) = -a1 + a2 + a3
+        x(4) = a1 + a5 - a6
+        x(5) = a1 - a5 + a6
+        x(6) = -a1 + a5 + a6
+        x(7) = a4 + a2 - a6
+        x(8) = a4 - a2 + a6
+        x(9) = -a4 + a2 + a6
+        x(10) = a4 + a5 - a3
+        x(11) = a4 - a5 + a3
+        x(12) = -a4 + a5 + a3
+        x = Anint(x * 100_dp) / 100_dp
+
+        Do k = 1, 12
+            If (x(k) >= 0) lu(k) = x(k) + eps
+        End Do
+        lu(13) = ma(4) + 1
+        li(1:3) = ma(1:3) + 1
+        li(4:6) = ma(4) - ma(1:3)
+        li(7:9) = li(4:6)
+        li(10:11) = na(2:3) - na(1)
+        li(12:13) = li(10:11)
+
+        Call sortArray(lu, 13)
+        Call sortArray(li, 13)
+
+        all = 0._dp
+        Do k = 1, 13
+            If (lu(k) /= li(k)) Then
+                If (lu(k) < li(k)) Then
+                    Call NGFJ(-1, lu(k), li(k), all)
+                Else
+                    Call NGFJ(1, li(k), lu(k), all)
+                End If
+            End If
+        End Do
+    
+        un = all / 2_dp
+        km = na(1) - ma(4) + 1
+        Do l = 1, km
+            k = ma(4) + l - 1
+            all = 0_dp
+            Call NGFJ(1, ma(4) + 1, k + 1, all)
+            Call NGFJ(-1, ma(4) - ma(1), k - ma(1), all)
+            Call NGFJ(-1, ma(4) - ma(2), k - ma(2), all)
+            Call NGFJ(-1, ma(4) - ma(3), k - ma(3), all)
+            Call NGFJ(-1, 0, k - ma(4), all)
+            Call NGFJ(-1, 0, na(1) - k, all)
+            Call NGFJ(-1, na(2) - na(1), na(2) - k, all)
+            Call NGFJ(-1, na(3) - na(1), na(3) - k, all)
+            fj6 = fj6 + (-1)**k * dexp(all)
+        End Do
+    
+        fj6 = dexp(un) * fj6
     End Function FJ6
 
-    Real(dp) Function FJ9(A11,A12,A13,A21,A22,A23,A31,A32,A33)
-      Implicit None
+    Real(dp) Function FJ9(a11, a12, a13, a21, a22, a23, a31, a32, a33)
+        Implicit None
 
-      Integer                :: N, M
-      Real(dp)               :: A11, A12, A13, A21, A22, A23, A31, A32, A33
-      Real(dp)               :: X, Y, A, K, D
-      Real(dp), Dimension(3) :: UP, DOUN
+        Real(dp), Intent(In) :: a11, a12, a13, a21, a22, a23, a31, a32, a33
 
-      CALL DELFJ(A11,A12,A13,N)
-      GO TO(10,3),N
-10    CALL DELFJ(A21,A22,A23,N)
-      GO TO(11,3),N
-11    CALL DELFJ(A31,A32,A33,N)
-      GO TO(12,3),N
-12    CALL DELFJ(A11,A21,A31,N)
-      GO TO(13,3),N
-13    CALL DELFJ(A12,A22,A32,N)
-      GO TO(14,3),N
-14    CALL DELFJ(A13,A23,A33,N)
-      GO TO(15,3),N
-15    UP(1)=A11+A33
-      DOUN(1)=dABS(A11-A33)
-      UP(2)=A32+A21
-      DOUN(2)=dABS(A32-A21)
-      UP(3)=A12+A23
-      DOUN(3)=dABS(A12-A23)
-      X=UP(1)
-      DO 1 N=2,3
-      IF(UP(N)-X) 6,1,1
-6     X=UP(N)
-1     CONTINUE
-      Y=DOUN(1)
-      DO 2 N=2,3
-      IF(DOUN(N)-Y) 2,2,7
-7     Y=DOUN(N)
-2     CONTINUE
-      IF(X-Y)3,8,8
-8     D=X-Y+1._dp
-      N=D
-      IF(dABS(D-N)-0.00001_dp) 9,3,3
-9     FJ9=0._dp
-      DO 4 K=1,N
-      A=Y+K-1._dp
-      M=2*A+0.00001_dp
-      FJ9=FJ9+(-1)**M*(M+1)*FJ6(A11,A21,A31,A32,A33,A)* &
-      FJ6(A12,A22,A32,A21,A,A23)*FJ6(A13,A23,A33,A,A11,A12)
-4     CONTINUE
-      GO TO 5
-3     FJ9=0._dp
-5     RETURN
+        Integer :: n, m, k
+        Real(dp) :: x, y, a, d
+        Real(dp), Dimension(3) :: up, down
+
+        fj9 = 0.0_dp
+
+        Call DELFJ(a11, a12, a13, n)
+        If (n /= 1) Return
+        Call DELFJ(a21, a22, a23, n)
+        If (n /= 1) Return
+        Call DELFJ(a31, a32, a33, n)
+        If (n /= 1) Return
+        Call DELFJ(a11, a21, a31, n)
+        If (n /= 1) Return
+        Call DELFJ(a12, a22, a32, n)
+        If (n /= 1) Return
+        Call DELFJ(a13, a23, a33, n)
+        If (n /= 1) Return
+
+        up(1) = a11 + a33
+        down(1) = dabs(a11 - a33)
+        up(2) = a32 + a21
+        down(2) = dabs(a32 - a21)
+        up(3) = a12 + a23
+        down(3) = dabs(a12 - a23)
+
+        x = Maxval(up)
+        y = Minval(down)
+        IF (x <= y) Return
+
+        d = x - y + 1.0_dp
+        n = Int(d)
+        If (dabs(d - Real(n, dp)) > 0.00001_dp) Return
+
+        Do k = 1, n
+            a = y + Real(k - 1, dp)
+            m = Int(2 * a + 0.00001_dp)
+            fj9 = fj9 + (-1)**m * (m + 1) * &
+                   FJ6(a11, a21, a31, a32, a33, a) * &
+                   FJ6(a12, a22, a32, a21, a, a23) * &
+                   FJ6(a13, a23, a33, a, a11, a12)
+        End Do
     End Function FJ9
 
-    Subroutine DELFJ(A,B,C,N)
-      Implicit None
+    Subroutine DELFJ(a, b, c, n)
+        Implicit None
 
-      Integer  :: N
-      Real(dp) :: X, Y, A, B, C
+        Real(dp), Intent(In) :: a, b, c
+        Integer, Intent(Out) :: n
+        Real(dp) :: x, y
 
-      X=A+B
-      Y=dABS(A-B)
-      IF(X-C) 1,2,2
-2     IF(Y-C) 3,3,1
-3     N=1
-      GO TO 4
-1     N=2
-4     RETURN
+        x = a + b
+        y = dabs(a - b)
+
+        If (x < c) Then
+            n = 2
+        Else If (y < c) Then
+            n = 1
+        Else
+            n = 2
+        End If
+
     End Subroutine DELFJ
 
-    Subroutine NGFJ(J,M,N)
-      Implicit None
+    Subroutine NGFJ(j, m, n, all)
+        Implicit None
 
-      Integer  :: J, K, L, M, N
-      Real(dp) :: AL
+        Integer, Intent(In) :: j, m, n
+        Real(dp), Intent(InOut) :: all
+        Integer  :: l
+        Real(dp) :: al
 
-      IF(M-N) 4,3,3
-4     K=M+1
-      DO 1 L=K,N
-      AL=dLOG(1._dp*L)
-1     ALL=ALL+J*AL
-3     RETURN
+        If (m < n) Then
+            Do l = m + 1, n
+                al = log(1.0_dp * l)
+                all = all + j * al
+            End Do
+        End If
+        
     End Subroutine NGFJ
 
-    Subroutine OBME(M1,M2)
-      Implicit None
+    Subroutine swap(m1, m2)
+        Implicit None
 
-      Integer :: N, M1, M2
+        Integer, Intent(InOut) :: m1, m2
+        Integer :: n
 
-      N=M1
-      M1=M2
-      M2=N
-      RETURN
-    End Subroutine OBME
+        n = m1
+        m1 = m2
+        m2 = n
+        
+    End Subroutine swap
 
-    Subroutine PORAD(I,N)
-      Implicit None
+    Subroutine sortArray(arr, n)
+        Implicit None
+        
+        Integer, Intent(In) :: n
+        Integer, Dimension(n), Intent(InOut) :: arr
 
-      Integer               :: N, K, L, K1, K2
-      Integer, Dimension(N) :: I
-      
-      K1=N-1
-      DO 1 K=1,K1
-      K2=K+1
-      DO 2 L=K2,N
-      IF(I(K)-I(L)) 2,2,3
-3     CALL OBME(I(K),I(L))
-2     CONTINUE
-1     CONTINUE
-      RETURN
-    End Subroutine PORAD
+        Integer :: i, j
+        
+        Do i = 1, n-1
+            Do j = i+1, n
+                If (arr(i) > arr(j)) Then
+                    Call swap(arr(i), arr(j))
+                End If
+              End Do
+        End Do
+
+    End Subroutine sortArray
 
 End Module


### PR DESCRIPTION
- refactored main programs for gfortran compatibility
- check_matrices.f90 - small new program check_matrices to check for errors in CONFp.HIJ and CONFp.JJJ
- updated matrix_io.f90 to use mpi_f08
- pconf.f90 -> pconf.F90, use preprocessing directives to compile ScaLAPACK routines
- pconf - fixed allocation of array E for LAPACK subroutines
- removed IPmr parameter from params.f90 and refactored IPmr-associated arrays
- removed IPmr parameter from all-order package and refactored IPmr-associated arrays using rec_unit module
- pconf - refactored KXIJ and KWeights into optional inputs
- removed IP1 parameter from params.f90 and refactored IP1-associated arrays from main programs
- add - increased allowed number of shells per configuration to up to 24